### PR TITLE
Allow configurable metadata fetch timeout for rebalances

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/KafkaIdealBalanceAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/KafkaIdealBalanceAction.java
@@ -18,6 +18,7 @@ package com.pinterest.orion.core.actions.kafka;
 import com.google.common.collect.Lists;
 import com.pinterest.orion.core.PluginConfigurationException;
 import com.pinterest.orion.core.actions.Action;
+import com.pinterest.orion.core.kafka.KafkaCluster;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +39,7 @@ public class KafkaIdealBalanceAction extends Action {
   private static final String[] attrArr = new String[]{ATTR_ACTUAL_ASSIGNMENTS_KEY, ATTR_IDEAL_ASSIGNMENTS_KEY, ATTR_TOPIC_KEY};
 
   public int batchSize = 60;
-  public long metadataTimeoutMs = 30_000L;
+  public long metadataTimeoutMs = KafkaCluster.DEFAULT_METADATA_TIMEOUT_MS;  // initialize as default
 
   @Override
   public void initialize(Map<String, Object> config) throws PluginConfigurationException {

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ReassignmentAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ReassignmentAction.java
@@ -47,8 +47,13 @@ public class ReassignmentAction extends AbstractKafkaAction {
   @Override
   public void run(String zkString, AdminClient adminClient) {
     Boolean waitForPrevious = false;
+    long metadataFetchTimeoutMs = 30_000L; // default
     Attribute attribute = getAttribute(ATTR_REASSIGNMENT_KEY);
+    Attribute metadataFetchTimeoutMsAttr = getAttribute(KafkaIdealBalanceAction.CONF_METADATA_FETCH_TIMEOUT_MS_KEY);
     KafkaCluster kakfaCluster = (KafkaCluster) getEngine().getCluster();
+    if (metadataFetchTimeoutMsAttr != null) {
+      metadataFetchTimeoutMs = metadataFetchTimeoutMsAttr.getValue();
+    }
     if (containsAttribute("wait_for_previous")) {
       waitForPrevious = getAttribute(this, "wait_for_previous").getValue();
     }
@@ -73,7 +78,7 @@ public class ReassignmentAction extends AbstractKafkaAction {
         }
 
         zkClient.create().forPath(REASSIGNMENT_PATH, assignmentJson.getBytes());
-        waitForISRsToMatchAssignments(kakfaCluster, assignmentMap, 15_000);
+        waitForISRsToMatchAssignments(kakfaCluster, assignmentMap, 15_000, metadataFetchTimeoutMs);
         waitForURPsToBeResolved(kakfaCluster, 15_000);
         CuratorClient.waitForZnodeToBeDeleted(zkClient, REASSIGNMENT_PATH);
         markSucceeded();
@@ -85,19 +90,21 @@ public class ReassignmentAction extends AbstractKafkaAction {
 
   private void waitForISRsToMatchAssignments(KafkaCluster cluster,
                                              Map<String, Map<Integer, List<Integer>>> assignments,
-                                             long checkFrequencyMillis)
+                                             long checkFrequencyMillis,
+                                             long metadataFetchTimeoutMs)
       throws Exception {
-    while (!doesISRsMatchAssignments(cluster, assignments)) {
+    while (!doesISRsMatchAssignments(cluster, assignments, metadataFetchTimeoutMs)) {
       logger.info("Waiting for ISRs to match assignments");
       Thread.sleep(checkFrequencyMillis);
     }
   }
 
   private boolean doesISRsMatchAssignments(KafkaCluster cluster,
-                                           Map<String, Map<Integer, List<Integer>>> assignments)
+                                           Map<String, Map<Integer, List<Integer>>> assignments,
+                                           long metadataFetchTimeoutMs)
       throws Exception {
     Map<String, Map<Integer, Set<Integer>>> isrs =
-        cluster.getTopicDescriptionFromKafka().values().stream().collect(Collectors.toMap(
+        cluster.getTopicDescriptionFromKafka(metadataFetchTimeoutMs).values().stream().collect(Collectors.toMap(
             KafkaTopicDescription::getName,
             td -> td.getPartitions().stream().collect(Collectors.toMap(
                 KafkaTopicPartitionInfo::getPartition,

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ReassignmentAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ReassignmentAction.java
@@ -47,7 +47,7 @@ public class ReassignmentAction extends AbstractKafkaAction {
   @Override
   public void run(String zkString, AdminClient adminClient) {
     Boolean waitForPrevious = false;
-    long metadataFetchTimeoutMs = 30_000L; // default
+    long metadataFetchTimeoutMs = KafkaCluster.DEFAULT_METADATA_TIMEOUT_MS; // default
     Attribute attribute = getAttribute(ATTR_REASSIGNMENT_KEY);
     Attribute metadataFetchTimeoutMsAttr = getAttribute(KafkaIdealBalanceAction.CONF_METADATA_FETCH_TIMEOUT_MS_KEY);
     KafkaCluster kakfaCluster = (KafkaCluster) getEngine().getCluster();

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
@@ -18,6 +18,7 @@ package com.pinterest.orion.core.automation.sensor.kafka;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -130,7 +131,8 @@ public class KafkaTopicSensor extends KafkaSensor {
     }
   }
 
-  private Map<String, KafkaTopicDescription> getTopicDescriptionFromKafka(KafkaCluster cluster) throws InterruptedException, ExecutionException {
+  private Map<String, KafkaTopicDescription> getTopicDescriptionFromKafka(KafkaCluster cluster)
+          throws InterruptedException, ExecutionException, TimeoutException {
     return cluster.getTopicDescriptionFromKafka();
   }
 

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqTopicSensor.java
@@ -59,7 +59,7 @@ public class MemqTopicSensor extends MemqSensor {
           readClusterClientMap.put(serversetFile, adminClient);
         }
         topicDescriptionMap.putAll(KafkaCluster.getTopicDescriptions(adminClient, logger,
-            topicDescriptionMap, cluster.getClusterId()));
+            topicDescriptionMap, cluster.getClusterId(), 30_000L));
         KafkaTopicSensor.populateTopicConfigInfo(adminClient, topicDescriptionMap);
       }
       MemqTopicDescription desc = new MemqTopicDescription();

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqTopicSensor.java
@@ -59,7 +59,7 @@ public class MemqTopicSensor extends MemqSensor {
           readClusterClientMap.put(serversetFile, adminClient);
         }
         topicDescriptionMap.putAll(KafkaCluster.getTopicDescriptions(adminClient, logger,
-            topicDescriptionMap, cluster.getClusterId(), 30_000L));
+            topicDescriptionMap, cluster.getClusterId(), KafkaCluster.DEFAULT_METADATA_TIMEOUT_MS));
         KafkaTopicSensor.populateTopicConfigInfo(adminClient, topicDescriptionMap);
       }
       MemqTopicDescription desc = new MemqTopicDescription();

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -174,14 +174,7 @@ public class KafkaCluster extends Cluster {
   @JsonIgnore
   public Map<String, KafkaTopicDescription> getTopicDescriptionFromKafka() throws InterruptedException,
                                                                                   ExecutionException, TimeoutException {
-    AdminClient adminClient = getAdminClient();
-    Map<String, KafkaTopicDescription> cachedTopicMap = containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY)
-        ? getAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY).getValue()
-        : null;
-    Map<String, KafkaTopicDescription> ret = getTopicDescriptions(adminClient, logger(),
-        cachedTopicMap,
-        clusterId, 30_000L);
-    return ret;
+    return getTopicDescriptionFromKafka(30_000L);
   }
 
   @JsonIgnore

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -62,6 +62,7 @@ public class KafkaCluster extends Cluster {
   private static final long serialVersionUID = 1L;
   private static final Logger logger = Logger.getLogger(KafkaCluster.class.getCanonicalName());
   public static final String ZOOKEEPER_CONNECT = "zookeeper.connect";
+  public static final long DEFAULT_METADATA_TIMEOUT_MS = 30_000L;
   private transient Properties props;
   private AdminClient adminClient;
   private KafkaConsumer<byte[], byte[]> kafkaConsumer;
@@ -174,7 +175,7 @@ public class KafkaCluster extends Cluster {
   @JsonIgnore
   public Map<String, KafkaTopicDescription> getTopicDescriptionFromKafka() throws InterruptedException,
                                                                                   ExecutionException, TimeoutException {
-    return getTopicDescriptionFromKafka(30_000L);
+    return getTopicDescriptionFromKafka(DEFAULT_METADATA_TIMEOUT_MS);
   }
 
   @JsonIgnore


### PR DESCRIPTION
Allow configurable timeout for metadata fetch in rebalancing action. Default is 30s.