### PR TITLE
Bump AWS SDK library version for EC2

### DIFF
--- a/deployments/orion-server-deployment/pom.xml
+++ b/deployments/orion-server-deployment/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
-			<version>2.13.34</version>
+			<version>2.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/orion-agent/pom.xml
+++ b/orion-agent/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>regions</artifactId>
-			<version>2.10.34</version>
+			<version>2.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>

--- a/orion-server/pom.xml
+++ b/orion-server/pom.xml
@@ -116,12 +116,12 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>ec2</artifactId>
-			<version>2.13.34</version>
+			<version>2.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>route53</artifactId>
-			<version>2.13.34</version>
+			<version>2.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This is to add support for c5ad instance types in `InstanceType` class.
These instance types are missing in version 2.13.34.