### PR TITLE
Topic Deletion

### DIFF
--- a/deployments/orion-server-deployment/conf/kafka-server.yaml
+++ b/deployments/orion-server-deployment/conf/kafka-server.yaml
@@ -58,7 +58,7 @@ clusterConfigs:
     configuration:
       serversetPath: /var/serverset/discovery.testkafka.prod
       clusterInfoDir: /opt/orion/configs/kafka/clusters/testkafka
-
+      enableTopicDeletion: false
 customApiFactoryClasses:
   - com.pinterest.orion.server.api.kafka.KafkaApiFactory
 plugins:

--- a/deployments/orion-server-deployment/conf/kafka-server.yaml
+++ b/deployments/orion-server-deployment/conf/kafka-server.yaml
@@ -162,6 +162,9 @@ plugins:
     - key: createtopic
       class: com.pinterest.orion.core.actions.kafka.AssignmentCreateKafkaTopicAction
       enabled: true
+    - key: deletetopic
+      class: com.pinterest.orion.core.actions.kafka.AssignmentDeleteKafkaTopicAction
+      enabled: true
     - key: rebalancetopic
       class: com.pinterest.orion.core.actions.kafka.KafkaIdealBalanceAction
       enabled: true

--- a/docs/Kafka/README.md
+++ b/docs/Kafka/README.md
@@ -13,6 +13,13 @@ Class: `com.pinterest.orion.core.actions.kafka.SimpleCreateKafkaTopicAction`
 Description: Creates a Kafka Topic with supplied attributes
 
 
+**Delete Kafka Topic**
+
+Class: `com.pinterest.orion.core.actions.kafka.AssignmentDeleteKafkaTopicAction`
+
+Description: Delete the specified kafka topic if it includes the field `"delete": true`
+
+
 **Partition Reassignment**
 
 Class: `com.pinterest.orion.core.actions.kafka.ReassignmentAction`

--- a/orion-server/scripts/config.yaml
+++ b/orion-server/scripts/config.yaml
@@ -147,6 +147,9 @@ plugins:
     - key: createtopic
       class: com.pinterest.orion.core.actions.kafka.AssignmentCreateKafkaTopicAction
       enabled: true
+    - key: deletetopic
+      class: com.pinterest.orion.core.actions.kafka.AssignmentDeleteKafkaTopicAction
+      enabled: true
     - key: rebalancetopic
       class: com.pinterest.orion.core.actions.kafka.KafkaIdealBalanceAction
       enabled: true

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/AssignmentDeleteKafkaTopicAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/AssignmentDeleteKafkaTopicAction.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright 2020 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.pinterest.orion.core.actions.kafka;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
+
+import java.util.Collections;
+
+public class AssignmentDeleteKafkaTopicAction extends AbstractKafkaAction {
+    public static final String ATTR_TOPIC_NAME_KEY = "topic";
+
+    @Override
+    public void run(String zkUrl, AdminClient adminClient) {
+        checkRequiredArgs(new String[] { ATTR_TOPIC_NAME_KEY });
+        String topicName = getAttribute(this, ATTR_TOPIC_NAME_KEY).getValue().toString();
+        DeleteTopicsResult result = adminClient.deleteTopics(Collections.singletonList(topicName));
+        try {
+            result.all().get();
+        } catch (Exception e) {
+            markFailed(e);
+            return;
+        }
+
+        try {
+            onTopicDeleted(topicName);
+        } catch (Exception e) {
+            markFailed(e);
+            return;
+        }
+        markSucceeded();
+    }
+
+    protected void onTopicDeleted(String topicName) throws Exception {
+        // e.g. some sort of notification
+    }
+
+    @Override
+    public String getName() {
+        return "Delete Kafka Topic " + getAttribute(this, ATTR_TOPIC_NAME_KEY).getValue().toString();
+    }
+}

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
@@ -92,6 +92,13 @@ public class BrokersetTopicOperator extends KafkaOperator {
       return;
     }
 
+    boolean enableTopicDeletion;
+    if (cluster.containsAttribute(KafkaClusterInfoSensor.ATTR_TOPIC_DELETION_ENABLED)) {
+      enableTopicDeletion = cluster.getAttribute(KafkaClusterInfoSensor.ATTR_TOPIC_DELETION_ENABLED).getValue();
+    } else {
+      enableTopicDeletion = false;
+    }
+
     Set<String> sensorSet = new HashSet<>();
 
     Attribute brokersetMapAttr = cluster.getAttribute(KafkaClusterInfoSensor.ATTR_BROKERSET_KEY);
@@ -133,7 +140,7 @@ public class BrokersetTopicOperator extends KafkaOperator {
       KafkaTopicDescription actualTopicDescription = topicDescriptionMap.get(topicName);
       Brokerset brokerset = brokersetMap.get(brokersetAlias);
 
-      if (topicAssignment.isDelete()) {
+      if (enableTopicDeletion && topicAssignment.isDelete()) {
         if (actualTopicDescription == null) {
           continue;
         }

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaClusterInfoSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaClusterInfoSensor.java
@@ -38,6 +38,7 @@ public class KafkaClusterInfoSensor extends KafkaSensor {
   public static final String ATTR_BROKERSET_KEY = "brokerset";
   public static final String CONF_CLUSTER_INFO_DIR_KEY = "clusterInfoDir";
   public static final String ATTR_TOPIC_ASSIGNMENTS_KEY = "topicAssignment";
+  public static final String ATTR_TOPIC_DELETION_ENABLED = "enableTopicDeletion";
 
   @Override
   public String getName() {

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -56,6 +56,8 @@ import com.pinterest.orion.core.actions.audit.ActionAuditor;
 import com.pinterest.orion.core.automation.operator.Operator;
 import com.pinterest.orion.core.automation.sensor.Sensor;
 import com.pinterest.orion.core.automation.sensor.kafka.KafkaTopicSensor;
+import com.pinterest.orion.core.automation.sensor.kafka.KafkaClusterInfoSensor;
+
 
 public class KafkaCluster extends Cluster {
 
@@ -122,6 +124,12 @@ public class KafkaCluster extends Cluster {
   @Override
   public void bootstrapClusterInfo(Map<String, Object> config) {
     props = new Properties();
+    if (config.containsKey(KafkaClusterInfoSensor.ATTR_TOPIC_DELETION_ENABLED)) {
+      setAttribute(
+              KafkaClusterInfoSensor.ATTR_TOPIC_DELETION_ENABLED,
+              config.get(KafkaClusterInfoSensor.ATTR_TOPIC_DELETION_ENABLED)
+      );
+    }
   }
 
   public void addBrokerset(Brokerset brokerset) {


### PR DESCRIPTION
Topic config files that include a top level entry of will result in the topic being deleted.

There is currently no other check/balance on the topic. If the config file is changed to include that flag, that topic will be removed. I'd love to hear any feedback about other potential handles to make this safer. On the other side I'm planning to do a similar alert setup to the topic creation flow

Testing: Tested locally with a local kafka cluster that Ping helped me set up.