### PR TITLE
Small change to the readme doc for increased clarity

### DIFF
--- a/docs/Kafka/README.md
+++ b/docs/Kafka/README.md
@@ -18,6 +18,8 @@ Description: Creates a Kafka Topic with supplied attributes
 Class: `com.pinterest.orion.core.actions.kafka.AssignmentDeleteKafkaTopicAction`
 
 Description: Delete the specified kafka topic if it includes the field `"delete": true`
+AND the server description includes `enableTopicDeletion: false` in the configuration of
+the specific cluster that has topics you want to delete.
 
 
 **Partition Reassignment**


### PR DESCRIPTION
I forgot to add a mention in the doc about the guard to prevent careless deletions using Orion. I added a blurb about it to make sure it would be obvious.

Testing: Didn't bother as this change is completely non-functional, just a readme modification