### PR TITLE
Catching all the possible exceptions for getting topic metadata

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -204,7 +204,7 @@ public class KafkaCluster extends Cluster {
     Set<String> topics;
     try {
       topics = adminClient.listTopics(new ListTopicsOptions().listInternal(true)).names().get(metadataFetchTimeoutMs, TimeUnit.MILLISECONDS);
-    } catch (ExecutionException e) {
+    } catch (Exception e) {
       if (cachedTopicMap != null) {
         logger.log(Level.WARNING,
             "Failed to list topics for " + clusterId + ", fallback to previous topic data.", e);


### PR DESCRIPTION
Currently this try/catch is only catching ExecutionException, so timeouts do not have a chance to recover like ExecutionExceptions do. 