### PR TITLE
Fixing failure to create topics

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
@@ -156,7 +156,6 @@ public class BrokersetTopicOperator extends KafkaOperator {
           } else {
             Action action = createDeleteTopicAction(topicAssignment.getTopicName(), sensorSet);
             logger.info("Topic(" + topicName + ") exists and is marked for deletion. Starting deletion.");
-            OrionServer.METRICS.counter(metric.resolve("deleted_topic")).inc();
             dispatch(action);
           }
         }

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
@@ -140,7 +140,7 @@ public class BrokersetTopicOperator extends KafkaOperator {
       Brokerset brokerset = brokersetMap.get(brokersetAlias);
 
       if (brokerset == null) {
-        logger.info("Topic(" + topicName + ") Attempted to use Brokerset(" + brokersetAlias + ") which doesn't exist.");
+        logger.warning("Topic(" + topicName + ") Attempted to use Brokerset(" + brokersetAlias + ") which doesn't exist.");
         continue;
       }
 

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
@@ -92,7 +92,7 @@ public class BrokersetTopicOperator extends KafkaOperator {
 
   @Override
   public void operate(KafkaCluster cluster) throws Exception {
-    MetricName metric = MetricName.build("pinterest_brokerset_topic_operator").tagged("cluster", cluster.getName());
+    MetricName metric = MetricName.build("brokerset_topic_operator").tagged("cluster", cluster.getName());
     AdminClient adminClient = cluster.getAdminClient();
     if (adminClient == null) {
       return;


### PR DESCRIPTION
BrokersetTopicOperator had an issue where if a topic which was marked for deletion had a brokerset that didn't exist then there would be a null pointer exception way down the line. Now this situation is logged and will cause the operator to move to the next topic instead of dying unceremoniously