### PR TITLE
Add configurable timeouts for sensors using Kafka Admin API

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerConfigSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerConfigSensor.java
@@ -18,6 +18,7 @@ package com.pinterest.orion.core.automation.sensor.kafka;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsOptions;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.ConfigResource;
@@ -54,8 +55,12 @@ public class KafkaBrokerConfigSensor extends KafkaSensor {
       brokerIds.add(new ConfigResource(ConfigResource.Type.BROKER, broker.idString()));
     }
 
+    DescribeConfigsOptions describeConfigsOptions = new DescribeConfigsOptions();
+    if (containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster)) {
+      describeConfigsOptions.timeoutMs(getKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
+    }
+    DescribeConfigsResult describeConfigs = adminClient.describeConfigs(brokerIds, describeConfigsOptions);
     // add broker configs
-    DescribeConfigsResult describeConfigs = adminClient.describeConfigs(brokerIds);
     Map<ConfigResource, Config> map = describeConfigs.all().get();
     for (Map.Entry<ConfigResource, Config> entry : map.entrySet()) {
       com.pinterest.orion.core.Node node = cluster.getNodeMap().get(entry.getKey().name());

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerSensor.java
@@ -44,7 +44,6 @@ public class KafkaBrokerSensor extends KafkaSensor {
   public static final String ATTR_BOOTSTRAP_SERVERS_KEY = "bootstrapBrokers";
   public static final String ATTR_CONTROLLER_ID_KEY = "controllerId";
   public static final String ATTR_BROKERS_KEY = "brokers";
-  public static final int KAFKA_ADMIN_REQUEST_TIMEOUT_SECONDS = 30;
 
   @Override
   public String getName() {
@@ -57,8 +56,11 @@ public class KafkaBrokerSensor extends KafkaSensor {
     if (adminClient == null) {
       adminClient = initializeAdminClient(cluster);
     }
-
-    DescribeClusterResult clusterResult = adminClient.describeCluster(new DescribeClusterOptions().timeoutMs(KAFKA_ADMIN_REQUEST_TIMEOUT_SECONDS * 1000));
+    DescribeClusterOptions describeClusterOptions = new DescribeClusterOptions();
+    if (containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster)) {
+      describeClusterOptions.timeoutMs(getKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
+    }
+    DescribeClusterResult clusterResult = adminClient.describeCluster(describeClusterOptions);
     Collection<org.apache.kafka.common.Node> brokersList = clusterResult.nodes().get();
     brokersList.stream().forEach(n -> {
       NodeInfo info = new NodeInfo();

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaLogDirectorySensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaLogDirectorySensor.java
@@ -47,7 +47,11 @@ public class KafkaLogDirectorySensor extends KafkaSensor {
       Map<Integer, org.apache.kafka.common.Node> attribute = cluster
           .getAttribute(KafkaBrokerSensor.ATTR_BROKERS_KEY).getValue();
       List<Integer> brokers = new ArrayList<>(attribute.keySet());
-      DescribeLogDirsResult describeLogDirs = adminClient.describeLogDirs(brokers);
+      DescribeLogDirsOptions describeLogDirsOptions = new DescribeLogDirsOptions();
+      if (containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster)) {
+        describeLogDirsOptions.timeoutMs(getKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
+      }
+      DescribeLogDirsResult describeLogDirs = adminClient.describeLogDirs(brokers, describeLogDirsOptions);
       Map<Integer, Map<String, LogDirInfo>> map = describeLogDirs.all().get();
       setHiddenAttribute(cluster, ATTR_BROKER_LOG_DIRS_KEY, map);
       logger.info("Updated log directory");

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
@@ -21,6 +21,21 @@ import com.pinterest.orion.core.kafka.KafkaCluster;
 
 public abstract class KafkaSensor extends Sensor {
 
+  // These cluster attributes are used to define the timeout values of the Kafka AdminClient API calls.
+  // If cluster does not have required attributes, the AdminClient call will use default timeout values.
+  // KafkaAdminClientClusterRequestTimeoutMs is used for AdminClient cluster/broker config APIs.
+  //    Ex: describeConfigs and describeCluster
+  // KafkaAdminClientTopicRequestTimeoutMs is used for AdminClient topic/partition related APIs.
+  //    Ex: describeLogDirs and listOffsets
+  // KafkaAdminClientConsumerGroupRequestTimeoutMs is used for AdminClient consumer group related APIs.
+  //    Ex: listConsumerGroups, describeConsumerGroups and listConsumerGroupOffsets
+  protected static final String ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY =
+          "KafkaAdminClientClusterRequestTimeoutMs";
+  protected static final String ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY =
+          "KafkaAdminClientTopicRequestTimeoutMs";
+  protected static final String ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY =
+          "KafkaAdminClientConsumerGroupRequestTimeoutMs";
+
   @Override
   public final void observe(Cluster cluster) throws Exception {
     if (logger == null) {
@@ -33,4 +48,30 @@ public abstract class KafkaSensor extends Sensor {
 
   public abstract void sense(KafkaCluster cluster) throws Exception;
 
+  protected static boolean containsKafkaAdminClientClusterRequestTimeoutMilliseconds(Cluster cluster) {
+    return cluster.containsAttribute(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+  }
+
+  protected static int getKafkaAdminClientClusterRequestTimeoutMilliseconds(Cluster cluster) {
+    return Integer.valueOf(
+              cluster.getAttribute(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY).getValue());
+  }
+
+  protected static boolean containsKafkaAdminClientTopicRequestTimeoutMilliseconds(Cluster cluster) {
+    return cluster.containsAttribute(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+  }
+
+  protected static int getKafkaAdminClientTopicRequestTimeoutMilliseconds(Cluster cluster) {
+    return Integer.valueOf(
+              cluster.getAttribute(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY).getValue());
+  }
+
+  protected static boolean containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(Cluster cluster) {
+    return cluster.containsAttribute(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+  }
+
+  protected static int getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(Cluster cluster) {
+    return Integer.valueOf(
+              cluster.getAttribute(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY).getValue());
+  }
 }

--- a/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
@@ -1,0 +1,59 @@
+package com.pinterest.orion.core.automation.sensor.kafka;
+
+import com.pinterest.orion.core.Attribute;
+import com.pinterest.orion.core.kafka.KafkaCluster;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class KafkaSensorTest {
+
+    @Test
+    public void testGetKafkaAdminClientClusterRequestTimeoutMilliseconds() throws Exception {
+        KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
+        Attribute valueAttribute = Mockito.mock(Attribute.class);
+        // Cluster does not have timeout attribute
+        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(false);
+        assertFalse(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
+        // Cluster has cluster admin client timeout attribute
+        Mockito.when(valueAttribute.getValue()).thenReturn("11111");
+        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(true);
+        Mockito.when(cluster.getAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(valueAttribute);
+        assertTrue(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
+        assertEquals(11111, KafkaSensor.getKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
+    }
+
+    @Test
+    public void testGetKafkaAdminClientTopicRequestTimeoutMilliseconds() throws Exception {
+        KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
+        Attribute valueAttribute = Mockito.mock(Attribute.class);
+        // Cluster does not have timeout attribute
+        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(false);
+        assertFalse(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
+        // Cluster has topic admin client timeout attribute
+        Mockito.when(valueAttribute.getValue()).thenReturn("22222");
+        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(true);
+        Mockito.when(cluster.getAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(valueAttribute);
+        assertTrue(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
+        assertEquals(22222, KafkaSensor.getKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
+    }
+
+    @Test
+    public void testGetKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() throws Exception {
+        KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
+        Attribute valueAttribute = Mockito.mock(Attribute.class);
+        // Cluster does not have timeout attribute
+        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(false);
+        assertFalse(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
+        // Cluster has consumer group admin client timeout attribute
+        Mockito.when(valueAttribute.getValue()).thenReturn("33333");
+        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(true);
+        Mockito.when(cluster.getAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(valueAttribute);
+        assertTrue(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
+        assertEquals(33333, KafkaSensor.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
+    }
+}


### PR DESCRIPTION
## Add configurable timeouts for sensors using Kafka Admin API.

### Background
Default timeout causes some sensors unnecessarily fail due to large data set. 

### Change
The sensor will load timeout value from cluster attribute and use the value as timeout parameter for Admin Client API call through request options. If cluster does not have required attributes, the AdminClient call will use default timeout values (empty option).

There are three types of attribute keys for three types of Admin Client API calls. 
- KafkaAdminClientClusterRequestTimeoutMs is used for AdminClient cluster/broker config APIs.
	- Ex: describeConfigs and describeCluster
- KafkaAdminClientTopicRequestTimeoutMs is used for AdminClient topic/partition related APIs.
	- Ex: describeLogDirs and listOffsets
- KafkaAdminClientConsumerGroupRequestTimeoutMs is used for AdminClient consumer group related APIs.
	- Ex: listConsumerGroups, describeConsumerGroups and listConsumerGroupOffsets

### Test
Add unit test for getting timeout cluster attributes 