### PR TITLE
Get kafka admin client timeout config from config atrribute

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
@@ -19,6 +19,9 @@ import com.pinterest.orion.core.Cluster;
 import com.pinterest.orion.core.automation.sensor.Sensor;
 import com.pinterest.orion.core.kafka.KafkaCluster;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public abstract class KafkaSensor extends Sensor {
 
   // These cluster attributes are used to define the timeout values of the Kafka AdminClient API calls.
@@ -30,11 +33,11 @@ public abstract class KafkaSensor extends Sensor {
   // KafkaAdminClientConsumerGroupRequestTimeoutMs is used for AdminClient consumer group related APIs.
   //    Ex: listConsumerGroups, describeConsumerGroups and listConsumerGroupOffsets
   protected static final String ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY =
-          "KafkaAdminClientClusterRequestTimeoutMs";
+          "kafkaAdminClientClusterRequestTimeoutMs";
   protected static final String ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY =
-          "KafkaAdminClientTopicRequestTimeoutMs";
+          "kafkaAdminClientTopicRequestTimeoutMs";
   protected static final String ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY =
-          "KafkaAdminClientConsumerGroupRequestTimeoutMs";
+          "kafkaAdminClientConsumerGroupRequestTimeoutMs";
 
   @Override
   public final void observe(Cluster cluster) throws Exception {
@@ -48,30 +51,38 @@ public abstract class KafkaSensor extends Sensor {
 
   public abstract void sense(KafkaCluster cluster) throws Exception;
 
+  private static Map<String, Object> getClusterConfMap(Cluster cluster) {
+    Map<String, Object> confMap = new HashMap<>();
+    if (cluster.containsAttribute(Cluster.ATTR_CONF_KEY)) {
+      confMap = cluster.getAttribute(Cluster.ATTR_CONF_KEY).getValue();
+    }
+    return confMap;
+  }
+
   protected static boolean containsKafkaAdminClientClusterRequestTimeoutMilliseconds(Cluster cluster) {
-    return cluster.containsAttribute(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+    return getClusterConfMap(cluster).containsKey(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY);
   }
 
   protected static int getKafkaAdminClientClusterRequestTimeoutMilliseconds(Cluster cluster) {
     return Integer.valueOf(
-              cluster.getAttribute(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY).getValue());
+            getClusterConfMap(cluster).get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
   }
 
   protected static boolean containsKafkaAdminClientTopicRequestTimeoutMilliseconds(Cluster cluster) {
-    return cluster.containsAttribute(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+    return getClusterConfMap(cluster).containsKey(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY);
   }
 
   protected static int getKafkaAdminClientTopicRequestTimeoutMilliseconds(Cluster cluster) {
     return Integer.valueOf(
-              cluster.getAttribute(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY).getValue());
+            getClusterConfMap(cluster).get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
   }
 
   protected static boolean containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(Cluster cluster) {
-    return cluster.containsAttribute(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+    return getClusterConfMap(cluster).containsKey(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY);
   }
 
   protected static int getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(Cluster cluster) {
     return Integer.valueOf(
-              cluster.getAttribute(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY).getValue());
+            getClusterConfMap(cluster).get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
   }
 }

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
@@ -52,11 +52,13 @@ public abstract class KafkaSensor extends Sensor {
   public abstract void sense(KafkaCluster cluster) throws Exception;
 
   private static Map<String, Object> getClusterConfMap(Cluster cluster) {
-    Map<String, Object> confMap = new HashMap<>();
     if (cluster.containsAttribute(Cluster.ATTR_CONF_KEY)) {
-      confMap = cluster.getAttribute(Cluster.ATTR_CONF_KEY).getValue();
+      Map<String, Object> confMap = cluster.getAttribute(Cluster.ATTR_CONF_KEY).getValue();
+      if (confMap != null) {
+        return confMap;
+      }
     }
-    return confMap;
+    return new HashMap<>();
   }
 
   protected static boolean containsKafkaAdminClientClusterRequestTimeoutMilliseconds(Cluster cluster) {

--- a/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
@@ -1,9 +1,13 @@
 package com.pinterest.orion.core.automation.sensor.kafka;
 
 import com.pinterest.orion.core.Attribute;
+import com.pinterest.orion.core.Cluster;
 import com.pinterest.orion.core.kafka.KafkaCluster;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -12,17 +16,22 @@ import static org.junit.Assert.assertTrue;
 
 public class KafkaSensorTest {
 
+    private static final Map<String, Object> EMPTY_MAP = new HashMap<>();
+    private static final Map<String, String> RESULT_MAP = new HashMap<String, String>() {{
+        put(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY, "11111");
+        put(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY, "22222");
+        put(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY, "33333");
+    }};
+
     @Test
     public void testGetKafkaAdminClientClusterRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
-        Attribute valueAttribute = Mockito.mock(Attribute.class);
+        Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
         // Cluster does not have timeout attribute
-        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(false);
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, EMPTY_MAP, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
         // Cluster has cluster admin client timeout attribute
-        Mockito.when(valueAttribute.getValue()).thenReturn("11111");
-        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(true);
-        Mockito.when(cluster.getAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(valueAttribute);
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, RESULT_MAP, System.currentTimeMillis()));
         assertTrue(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
         assertEquals(11111, KafkaSensor.getKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
     }
@@ -30,14 +39,12 @@ public class KafkaSensorTest {
     @Test
     public void testGetKafkaAdminClientTopicRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
-        Attribute valueAttribute = Mockito.mock(Attribute.class);
+        Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
         // Cluster does not have timeout attribute
-        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(false);
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, EMPTY_MAP, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
-        // Cluster has topic admin client timeout attribute
-        Mockito.when(valueAttribute.getValue()).thenReturn("22222");
-        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(true);
-        Mockito.when(cluster.getAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(valueAttribute);
+        // Cluster has cluster admin client timeout attribute
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, RESULT_MAP, System.currentTimeMillis()));
         assertTrue(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
         assertEquals(22222, KafkaSensor.getKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
     }
@@ -45,14 +52,12 @@ public class KafkaSensorTest {
     @Test
     public void testGetKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
-        Attribute valueAttribute = Mockito.mock(Attribute.class);
+        Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
         // Cluster does not have timeout attribute
-        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(false);
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, EMPTY_MAP, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
-        // Cluster has consumer group admin client timeout attribute
-        Mockito.when(valueAttribute.getValue()).thenReturn("33333");
-        Mockito.when(cluster.containsAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(true);
-        Mockito.when(cluster.getAttribute(KafkaSensor.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)).thenReturn(valueAttribute);
+        // Cluster has cluster admin client timeout attribute
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, RESULT_MAP, System.currentTimeMillis()));
         assertTrue(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
         assertEquals(33333, KafkaSensor.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
     }

--- a/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
@@ -27,6 +27,9 @@ public class KafkaSensorTest {
     public void testGetKafkaAdminClientClusterRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
         Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
+        // Cluster config is null
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, null, System.currentTimeMillis()));
+        assertFalse(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
         // Cluster does not have timeout attribute
         Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, EMPTY_MAP, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
@@ -40,6 +43,9 @@ public class KafkaSensorTest {
     public void testGetKafkaAdminClientTopicRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
         Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
+        // Cluster config is null
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, null, System.currentTimeMillis()));
+        assertFalse(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
         // Cluster does not have timeout attribute
         Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, EMPTY_MAP, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
@@ -53,6 +59,9 @@ public class KafkaSensorTest {
     public void testGetKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
         Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
+        // Cluster config is null
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, null, System.currentTimeMillis()));
+        assertFalse(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
         // Cluster does not have timeout attribute
         Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, EMPTY_MAP, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));


### PR DESCRIPTION
Cluster configurations in yaml file are not added as cluster attributes automatically. They are stored in cluster configuration attribute map after initialization. This commit updates the getKafkaAdminClient*RequestTimeoutMilliseconds function to get value from cluster conf attribute map instead of cluster attribute. 

Change the config keys to make them start with lower letter. 

Update unit test 