### PR TITLE
Add logic to handle null value from cluster.getAttribute

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensor.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.pinterest.orion.core.automation.sensor.kafka;
 
+import com.pinterest.orion.core.Attribute;
 import com.pinterest.orion.core.Cluster;
 import com.pinterest.orion.core.automation.sensor.Sensor;
 import com.pinterest.orion.core.kafka.KafkaCluster;
@@ -53,9 +54,12 @@ public abstract class KafkaSensor extends Sensor {
 
   private static Map<String, Object> getClusterConfMap(Cluster cluster) {
     if (cluster.containsAttribute(Cluster.ATTR_CONF_KEY)) {
-      Map<String, Object> confMap = cluster.getAttribute(Cluster.ATTR_CONF_KEY).getValue();
-      if (confMap != null) {
-        return confMap;
+      Attribute confAttribute = cluster.getAttribute(Cluster.ATTR_CONF_KEY);
+      if (confAttribute != null) {
+        Map<String, Object> confMap = confAttribute.getValue();
+        if (confMap != null) {
+          return confMap;
+        }
       }
     }
     return new HashMap<>();

--- a/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaSensorTest.java
@@ -27,7 +27,10 @@ public class KafkaSensorTest {
     public void testGetKafkaAdminClientClusterRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
         Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
-        // Cluster config is null
+        // Cluster config attribute is null
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(null);
+        assertFalse(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
+        // Cluster config attribute value is null
         Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, null, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientClusterRequestTimeoutMilliseconds(cluster));
         // Cluster does not have timeout attribute
@@ -43,7 +46,10 @@ public class KafkaSensorTest {
     public void testGetKafkaAdminClientTopicRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
         Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
-        // Cluster config is null
+        // Cluster config attribute is null
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(null);
+        assertFalse(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
+        // Cluster config attribute value is null
         Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, null, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientTopicRequestTimeoutMilliseconds(cluster));
         // Cluster does not have timeout attribute
@@ -59,7 +65,10 @@ public class KafkaSensorTest {
     public void testGetKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() throws Exception {
         KafkaCluster cluster = Mockito.mock(KafkaCluster.class);
         Mockito.when(cluster.containsAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(true);
-        // Cluster config is null
+        // Cluster config attribute is null
+        Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(null);
+        assertFalse(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
+        // Cluster config attribute value is null
         Mockito.when(cluster.getAttribute(Cluster.ATTR_CONF_KEY)).thenReturn(new Attribute(null, null, System.currentTimeMillis()));
         assertFalse(KafkaSensor.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds(cluster));
         // Cluster does not have timeout attribute


### PR DESCRIPTION
Add logic to handle null value from cluster.getAttribute

cluster.getAttribute(Cluster.ATTR_CONF_KEY) might be null. If it's null, it can trigger NPE. Add logic to prevent this from causing failures. 