### PR TITLE
Add logging into KafkaCluster methods; Return default value with WARN message if the get timeout function is called but the value does not exist

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerConfigSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerConfigSensor.java
@@ -56,8 +56,9 @@ public class KafkaBrokerConfigSensor extends KafkaSensor {
     }
 
     DescribeConfigsOptions describeConfigsOptions = new DescribeConfigsOptions();
-    if (cluster.containsKafkaAdminClientClusterRequestTimeoutMilliseconds()) {
-      describeConfigsOptions.timeoutMs(cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
+    int kafkaAdminClientClusterRequestTimeoutMs = cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds();
+    if (kafkaAdminClientClusterRequestTimeoutMs > 0) {
+      describeConfigsOptions.timeoutMs(kafkaAdminClientClusterRequestTimeoutMs);
     }
     DescribeConfigsResult describeConfigs = adminClient.describeConfigs(brokerIds, describeConfigsOptions);
     // add broker configs

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaBrokerSensor.java
@@ -57,8 +57,9 @@ public class KafkaBrokerSensor extends KafkaSensor {
       adminClient = initializeAdminClient(cluster);
     }
     DescribeClusterOptions describeClusterOptions = new DescribeClusterOptions();
-    if (cluster.containsKafkaAdminClientClusterRequestTimeoutMilliseconds()) {
-      describeClusterOptions.timeoutMs(cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
+    int kafkaAdminClientClusterRequestTimeoutMs = cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds();
+    if (kafkaAdminClientClusterRequestTimeoutMs > 0) {
+      describeClusterOptions.timeoutMs(kafkaAdminClientClusterRequestTimeoutMs);
     }
     DescribeClusterResult clusterResult = adminClient.describeCluster(describeClusterOptions);
     Collection<org.apache.kafka.common.Node> brokersList = clusterResult.nodes().get();

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaConsumerGroupDescriptionSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaConsumerGroupDescriptionSensor.java
@@ -41,9 +41,10 @@ public class KafkaConsumerGroupDescriptionSensor extends KafkaSensor {
 
     ListConsumerGroupsOptions listConsumerGroupsOptions = new ListConsumerGroupsOptions();
     DescribeConsumerGroupsOptions describeConsumerGroupsOptions = new DescribeConsumerGroupsOptions();
-    if (cluster.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds()) {
-      listConsumerGroupsOptions.timeoutMs(cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
-      describeConsumerGroupsOptions.timeoutMs(cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
+    int kafkaAdminClientConsumerGroupRequestTimeoutMs = cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds();
+    if (kafkaAdminClientConsumerGroupRequestTimeoutMs > 0) {
+      listConsumerGroupsOptions.timeoutMs(kafkaAdminClientConsumerGroupRequestTimeoutMs);
+      describeConsumerGroupsOptions.timeoutMs(kafkaAdminClientConsumerGroupRequestTimeoutMs);
     }
     long start = System.currentTimeMillis();
     Collection<ConsumerGroupListing> listConsumerGroupResult = adminClient.listConsumerGroups(

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaConsumerGroupOffsetSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaConsumerGroupOffsetSensor.java
@@ -79,8 +79,9 @@ public class KafkaConsumerGroupOffsetSensor extends KafkaSensor {
     Map<TopicPartition, TopicPartitionOffsets> topicPartitionOffsetsMap = cluster.getAttribute(KafkaTopicOffsetSensor.ATTR_TOPIC_OFFSET_KEY).getValue();
     List<KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> offsetFutures = new ArrayList<>();
     ListConsumerGroupOffsetsOptions listConsumerGroupOffsetsOptions = new ListConsumerGroupOffsetsOptions();
-    if (cluster.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds()) {
-      listConsumerGroupOffsetsOptions.timeoutMs(cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
+    int kafkaAdminClientConsumerGroupRequestTimeoutMs = cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds();
+    if (kafkaAdminClientConsumerGroupRequestTimeoutMs > 0) {
+      listConsumerGroupOffsetsOptions.timeoutMs(kafkaAdminClientConsumerGroupRequestTimeoutMs);
     }
     for (String groupId : groupIds) {
       ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult = adminClient.listConsumerGroupOffsets(

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaLogDirectorySensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaLogDirectorySensor.java
@@ -48,8 +48,9 @@ public class KafkaLogDirectorySensor extends KafkaSensor {
           .getAttribute(KafkaBrokerSensor.ATTR_BROKERS_KEY).getValue();
       List<Integer> brokers = new ArrayList<>(attribute.keySet());
       DescribeLogDirsOptions describeLogDirsOptions = new DescribeLogDirsOptions();
-      if (cluster.containsKafkaAdminClientTopicRequestTimeoutMilliseconds()) {
-        describeLogDirsOptions.timeoutMs(cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
+      int kafkaAdminClientTopicRequestTimeoutMs = cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds();
+      if (kafkaAdminClientTopicRequestTimeoutMs > 0) {
+        describeLogDirsOptions.timeoutMs(kafkaAdminClientTopicRequestTimeoutMs);
       }
       DescribeLogDirsResult describeLogDirs = adminClient.describeLogDirs(brokers, describeLogDirsOptions);
       Map<Integer, Map<String, LogDirInfo>> map = describeLogDirs.all().get();

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicOffsetSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicOffsetSensor.java
@@ -44,7 +44,7 @@ public class KafkaTopicOffsetSensor extends KafkaSensor {
   public static final String ATTR_TOPIC_OFFSET_KEY = "topicOffsets";
 
   private static final int OFFSET_API_BATCH_SIZE = 1_000;
-  private static int kafkaAdminClientTopicRequestTimeout = -1; // -1 means using default value.
+  private static int kafkaAdminClientTopicRequestTimeoutMs = -1; // -1 means using default value.
 
   @Override
   public void sense(KafkaCluster cluster) throws Exception {
@@ -59,9 +59,7 @@ public class KafkaTopicOffsetSensor extends KafkaSensor {
     }
 
     Map<String, KafkaTopicDescription> topicDescriptionMap = cluster.getAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY).getValue();
-    if (cluster.containsKafkaAdminClientTopicRequestTimeoutMilliseconds()) {
-      kafkaAdminClientTopicRequestTimeout = cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds();
-    }
+    kafkaAdminClientTopicRequestTimeoutMs = cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds();
 
     try {
       Map<TopicPartition, TopicPartitionOffsets> topicPartitionOffsetMap = getTopicOffsets(adminClient, topicDescriptionMap.values());
@@ -109,8 +107,8 @@ public class KafkaTopicOffsetSensor extends KafkaSensor {
     List<KafkaFuture<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>>> beginningOffsetsFutures = new ArrayList<>();
     List<KafkaFuture<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>>> endOffsetsFutures = new ArrayList<>();
     ListOffsetsOptions listOffsetsOptions = new ListOffsetsOptions();
-    if (kafkaAdminClientTopicRequestTimeout > 0) {
-      listOffsetsOptions.timeoutMs(kafkaAdminClientTopicRequestTimeout);
+    if (kafkaAdminClientTopicRequestTimeoutMs > 0) {
+      listOffsetsOptions.timeoutMs(kafkaAdminClientTopicRequestTimeoutMs);
     }
     for (int i = 0; i < batchCount; ++i) {
       beginningOffsetsFutures.add(adminClient.listOffsets(partitionsBeginningOffsetsReqBatches.get(i), listOffsetsOptions).all());

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
@@ -60,9 +60,7 @@ public class KafkaTopicSensor extends KafkaSensor {
     } else {
       assignments = new ArrayList<>();
     }
-    if (cluster.containsKafkaAdminClientClusterRequestTimeoutMilliseconds()) {
-      kafkaAdminClientClusterRequestTimeoutMs = cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds();
-    }
+    kafkaAdminClientClusterRequestTimeoutMs = cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds();
     Map<String, KafkaTopicDescription> topicDescriptionMap = getTopicDescriptionFromKafka(cluster);
     try {
       populateTopicBrokersetInfo(assignments, topicDescriptionMap);

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -64,6 +64,7 @@ public class KafkaCluster extends Cluster {
 
   // These cluster attributes are used to define the timeout values of the Kafka AdminClient API calls.
   // If cluster does not have required attributes, the AdminClient call will use default timeout values.
+  //    The get methods will return -1.
   // KafkaAdminClientClusterRequestTimeoutMs is used for AdminClient cluster/broker config APIs.
   //    Ex: describeConfigs and describeCluster
   // KafkaAdminClientTopicRequestTimeoutMs is used for AdminClient topic/partition related APIs.
@@ -76,7 +77,6 @@ public class KafkaCluster extends Cluster {
           "kafkaAdminClientTopicRequestTimeoutMs";
   protected static final String ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY =
           "kafkaAdminClientConsumerGroupRequestTimeoutMs";
-  public static final int DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS = 30000;
 
   private static final long serialVersionUID = 1L;
   private static final Logger logger = Logger.getLogger(KafkaCluster.class.getCanonicalName());
@@ -126,8 +126,9 @@ public class KafkaCluster extends Cluster {
     int defaultRf = -1;
     try {
       DescribeClusterOptions describeClusterOptions = new DescribeClusterOptions();
-      if (containsKafkaAdminClientClusterRequestTimeoutMilliseconds()) {
-        describeClusterOptions.timeoutMs(getKafkaAdminClientClusterRequestTimeoutMilliseconds());
+      int kafkaAdminClientClusterRequestTimeoutMs = getKafkaAdminClientClusterRequestTimeoutMilliseconds();
+      if (kafkaAdminClientClusterRequestTimeoutMs > 0) {
+        describeClusterOptions.timeoutMs(kafkaAdminClientClusterRequestTimeoutMs);
       }
       Set<Integer> nodeIds = adminClient.describeCluster(describeClusterOptions).nodes().get().stream()
           .map(org.apache.kafka.common.Node::id).collect(Collectors.toSet());
@@ -198,8 +199,9 @@ public class KafkaCluster extends Cluster {
   @JsonIgnore
   public Map<String, KafkaTopicDescription> getTopicDescriptionFromKafka() throws InterruptedException,
                                                                                   ExecutionException, TimeoutException {
-    if (containsKafkaAdminClientTopicRequestTimeoutMilliseconds()) {
-      return getTopicDescriptionFromKafka(getKafkaAdminClientTopicRequestTimeoutMilliseconds());
+    int kafkaAdminClientTopicRequestTimeoutMs = getKafkaAdminClientTopicRequestTimeoutMilliseconds();
+    if (kafkaAdminClientTopicRequestTimeoutMs > 0) {
+      return getTopicDescriptionFromKafka(kafkaAdminClientTopicRequestTimeoutMs);
     }
     return getTopicDescriptionFromKafka(DEFAULT_METADATA_TIMEOUT_MS);
   }
@@ -395,60 +397,39 @@ public class KafkaCluster extends Cluster {
     return new HashMap<>();
   }
 
-  public boolean containsKafkaAdminClientClusterRequestTimeoutMilliseconds() {
-    return getClusterConfMap().containsKey(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY);
-  }
-
   public int getKafkaAdminClientClusterRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
-    int timeoutMs = DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS;
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
-      timeoutMs = Integer.valueOf(
+      int timeoutMs = Integer.valueOf(
               clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
       logger.log(Level.INFO,
               "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-    } else {
-      logger.log(Level.WARNING,
-              "getKafkaAdminClientClusterRequestTimeoutMilliseconds is called without required value. Use default value: " + timeoutMs);
+      return timeoutMs;
     }
-    return timeoutMs;
-  }
-
-  public boolean containsKafkaAdminClientTopicRequestTimeoutMilliseconds() {
-    return getClusterConfMap().containsKey(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+    return -1;
   }
 
   public int getKafkaAdminClientTopicRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
-    int timeoutMs = DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS;
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
-      timeoutMs = Integer.valueOf(
+      int timeoutMs = Integer.valueOf(
               clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
       logger.log(Level.INFO,
               "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-    } else {
-      logger.log(Level.WARNING,
-              "getKafkaAdminClientTopicRequestTimeoutMilliseconds is called without required value. Use default value: " + timeoutMs);
+      return timeoutMs;
     }
-    return timeoutMs;
-  }
-
-  public boolean containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() {
-    return getClusterConfMap().containsKey(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+    return -1;
   }
 
   public int getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
-    int timeoutMs = DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS;
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
-      timeoutMs = Integer.valueOf(
+      int timeoutMs = Integer.valueOf(
               clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
       logger.log(Level.INFO,
               "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-    } else {
-      logger.log(Level.WARNING,
-              "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds is called without required value. Use default value: " + timeoutMs);
+      return timeoutMs;
     }
-    return timeoutMs;
+    return -1;
   }
 }

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -400,11 +400,13 @@ public class KafkaCluster extends Cluster {
   public int getKafkaAdminClientClusterRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
-      int timeoutMs = Integer.valueOf(
-              clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
-      logger.log(Level.INFO,
-              "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-      return timeoutMs;
+      Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+      if (timeoutObject != null) {
+        int timeoutMs = Integer.valueOf((String) timeoutObject);
+        logger.log(Level.INFO,
+                "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        return timeoutMs;
+      }
     }
     return -1;
   }
@@ -412,11 +414,13 @@ public class KafkaCluster extends Cluster {
   public int getKafkaAdminClientTopicRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
-      int timeoutMs = Integer.valueOf(
-              clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
-      logger.log(Level.INFO,
-              "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-      return timeoutMs;
+      Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+      if (timeoutObject != null) {
+        int timeoutMs = Integer.valueOf((String) timeoutObject);
+        logger.log(Level.INFO,
+                "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        return timeoutMs;
+      }
     }
     return -1;
   }
@@ -424,11 +428,13 @@ public class KafkaCluster extends Cluster {
   public int getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
-      int timeoutMs = Integer.valueOf(
-              clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
-      logger.log(Level.INFO,
-              "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-      return timeoutMs;
+      Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY);
+      if (timeoutObject != null) {
+        int timeoutMs = Integer.valueOf((String) timeoutObject);
+        logger.log(Level.INFO,
+                "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        return timeoutMs;
+      }
     }
     return -1;
   }

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -76,6 +76,7 @@ public class KafkaCluster extends Cluster {
           "kafkaAdminClientTopicRequestTimeoutMs";
   protected static final String ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY =
           "kafkaAdminClientConsumerGroupRequestTimeoutMs";
+  public static final int DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS = 30000;
 
   private static final long serialVersionUID = 1L;
   private static final Logger logger = Logger.getLogger(KafkaCluster.class.getCanonicalName());
@@ -399,8 +400,18 @@ public class KafkaCluster extends Cluster {
   }
 
   public int getKafkaAdminClientClusterRequestTimeoutMilliseconds() {
-    return Integer.valueOf(
-            getClusterConfMap().get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
+    Map<String, Object> clusterConfMap = getClusterConfMap();
+    int timeoutMs = DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS;
+    if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
+      timeoutMs = Integer.valueOf(
+              clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
+      logger.log(Level.INFO,
+              "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+    } else {
+      logger.log(Level.WARNING,
+              "getKafkaAdminClientClusterRequestTimeoutMilliseconds is called without required value. Use default value: " + timeoutMs);
+    }
+    return timeoutMs;
   }
 
   public boolean containsKafkaAdminClientTopicRequestTimeoutMilliseconds() {
@@ -408,8 +419,18 @@ public class KafkaCluster extends Cluster {
   }
 
   public int getKafkaAdminClientTopicRequestTimeoutMilliseconds() {
-    return Integer.valueOf(
-            getClusterConfMap().get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
+    Map<String, Object> clusterConfMap = getClusterConfMap();
+    int timeoutMs = DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS;
+    if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
+      timeoutMs = Integer.valueOf(
+              clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
+      logger.log(Level.INFO,
+              "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+    } else {
+      logger.log(Level.WARNING,
+              "getKafkaAdminClientTopicRequestTimeoutMilliseconds is called without required value. Use default value: " + timeoutMs);
+    }
+    return timeoutMs;
   }
 
   public boolean containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() {
@@ -417,8 +438,17 @@ public class KafkaCluster extends Cluster {
   }
 
   public int getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() {
-    return Integer.valueOf(
-            getClusterConfMap().get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
+    Map<String, Object> clusterConfMap = getClusterConfMap();
+    int timeoutMs = DEFAULT_KAFKA_ADMIN_CLIENT_REQUEST_TIMEOUT_MILLISECONDS;
+    if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
+      timeoutMs = Integer.valueOf(
+              clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY).toString());
+      logger.log(Level.INFO,
+              "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+    } else {
+      logger.log(Level.WARNING,
+              "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds is called without required value. Use default value: " + timeoutMs);
+    }
+    return timeoutMs;
   }
-
 }

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -406,6 +406,9 @@ public class KafkaCluster extends Cluster {
         logger.log(Level.INFO,
                 "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
         return timeoutMs;
+      } else {
+        logger.log(Level.WARNING,
+                ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is null.");
       }
     }
     return -1;
@@ -420,6 +423,9 @@ public class KafkaCluster extends Cluster {
         logger.log(Level.INFO,
                 "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
         return timeoutMs;
+      } else {
+        logger.log(Level.WARNING,
+                ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is null.");
       }
     }
     return -1;
@@ -434,6 +440,9 @@ public class KafkaCluster extends Cluster {
         logger.log(Level.INFO,
                 "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
         return timeoutMs;
+      } else {
+        logger.log(Level.WARNING,
+                ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is null.");
       }
     }
     return -1;

--- a/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
@@ -7,8 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 public class KafkaClusterTest {
@@ -25,16 +23,15 @@ public class KafkaClusterTest {
         KafkaCluster cluster = new KafkaCluster("", "", Collections.emptyList(),
                 Collections.emptyList(), null, null, null, null, null);
         // Cluster config attribute is null
-        assertFalse(cluster.containsKafkaAdminClientClusterRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
         // Cluster config attribute value is null
         cluster.setAttribute(cluster.ATTR_CONF_KEY, null);
-        assertFalse(cluster.containsKafkaAdminClientClusterRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
         // Cluster does not have timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, EMPTY_MAP);
-        assertFalse(cluster.containsKafkaAdminClientClusterRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
         // Cluster has cluster admin client timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_MAP);
-        assertTrue(cluster.containsKafkaAdminClientClusterRequestTimeoutMilliseconds());
         assertEquals(11111, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
     }
 
@@ -43,16 +40,15 @@ public class KafkaClusterTest {
         KafkaCluster cluster = new KafkaCluster("", "", Collections.emptyList(),
                 Collections.emptyList(), null, null, null, null, null);
         // Cluster config attribute is null
-        assertFalse(cluster.containsKafkaAdminClientTopicRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
         // Cluster config attribute value is null
         cluster.setAttribute(cluster.ATTR_CONF_KEY, null);
-        assertFalse(cluster.containsKafkaAdminClientTopicRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
         // Cluster does not have timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, EMPTY_MAP);
-        assertFalse(cluster.containsKafkaAdminClientTopicRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
         // Cluster has topic admin client timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_MAP);
-        assertTrue(cluster.containsKafkaAdminClientTopicRequestTimeoutMilliseconds());
         assertEquals(22222, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
     }
 
@@ -61,16 +57,15 @@ public class KafkaClusterTest {
         KafkaCluster cluster = new KafkaCluster("", "", Collections.emptyList(),
                 Collections.emptyList(), null, null, null, null, null);
         // Cluster config attribute is null
-        assertFalse(cluster.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
         // Cluster config attribute value is null
         cluster.setAttribute(cluster.ATTR_CONF_KEY, null);
-        assertFalse(cluster.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
         // Cluster does not have timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, EMPTY_MAP);
-        assertFalse(cluster.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
+        assertEquals(-1, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
         // Cluster has consumer group admin client timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_MAP);
-        assertTrue(cluster.containsKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
         assertEquals(33333, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
     }
 }


### PR DESCRIPTION
The previous change gets NPE from getKafkaAdminClientClusterRequestTimeoutMilliseconds. All KafkaCluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds happens after containsKafkaAdminClientClusterRequestTimeoutMilliseconds. I don't know why the error can happen. 

I have one assumption that both containsKafkaAdminClientClusterRequestTimeoutMilliseconds and getKafkaAdminClientClusterRequestTimeoutMilliseconds are calling getClusterConfMap. But getClusterConfMap is not guarantee to return the same thing. Cluster config might be changed or updated between two call.

Therefore, I combine get and contain function. If the value does not exist, use -1 to indicate it. This can make two functions atomic. The getClusterConfMap will only be called once for both check and get value. 

Add logs for easy debugging this time. 