### PR TITLE
Add object type check so KafkaCluster can support both String and int

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -403,11 +403,7 @@ public class KafkaCluster extends Cluster {
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
       Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY);
       if (timeoutObject != null) {
-        if (timeoutObject instanceof String) {
-          timeoutMs = Integer.valueOf((String) timeoutObject);
-          logger.log(Level.INFO,
-                  "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-        } else if (timeoutObject instanceof Integer) {
+        if (timeoutObject instanceof Integer) {
           timeoutMs = (int) timeoutObject;
           logger.log(Level.INFO,
                   "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
@@ -429,11 +425,7 @@ public class KafkaCluster extends Cluster {
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
       Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY);
       if (timeoutObject != null) {
-        if (timeoutObject instanceof String) {
-          timeoutMs = Integer.valueOf((String) timeoutObject);
-          logger.log(Level.INFO,
-                  "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-        } else if (timeoutObject instanceof Integer) {
+        if (timeoutObject instanceof Integer) {
           timeoutMs = (int) timeoutObject;
           logger.log(Level.INFO,
                   "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
@@ -455,11 +447,7 @@ public class KafkaCluster extends Cluster {
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
       Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY);
       if (timeoutObject != null) {
-        if (timeoutObject instanceof String) {
-          timeoutMs = Integer.valueOf((String) timeoutObject);
-          logger.log(Level.INFO,
-                  "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-        } else if (timeoutObject instanceof Integer) {
+        if (timeoutObject instanceof Integer) {
           timeoutMs = (int) timeoutObject;
           logger.log(Level.INFO,
                   "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -399,52 +399,79 @@ public class KafkaCluster extends Cluster {
 
   public int getKafkaAdminClientClusterRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
+    int timeoutMs = -1;
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
       Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY);
       if (timeoutObject != null) {
-        int timeoutMs = Integer.valueOf((String) timeoutObject);
-        logger.log(Level.INFO,
-                "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-        return timeoutMs;
+        if (timeoutObject instanceof String) {
+          timeoutMs = Integer.valueOf((String) timeoutObject);
+          logger.log(Level.INFO,
+                  "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        } else if (timeoutObject instanceof Integer) {
+          timeoutMs = (int) timeoutObject;
+          logger.log(Level.INFO,
+                  "getKafkaAdminClientClusterRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        } else {
+          logger.log(Level.WARNING,
+                  ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is unacceptable type.");
+        }
       } else {
         logger.log(Level.WARNING,
                 ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is null.");
       }
     }
-    return -1;
+    return timeoutMs;
   }
 
   public int getKafkaAdminClientTopicRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
+    int timeoutMs = -1;
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
       Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY);
       if (timeoutObject != null) {
-        int timeoutMs = Integer.valueOf((String) timeoutObject);
-        logger.log(Level.INFO,
-                "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-        return timeoutMs;
+        if (timeoutObject instanceof String) {
+          timeoutMs = Integer.valueOf((String) timeoutObject);
+          logger.log(Level.INFO,
+                  "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        } else if (timeoutObject instanceof Integer) {
+          timeoutMs = (int) timeoutObject;
+          logger.log(Level.INFO,
+                  "getKafkaAdminClientTopicRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        } else {
+          logger.log(Level.WARNING,
+                  ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is unacceptable type.");
+        }
       } else {
         logger.log(Level.WARNING,
                 ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is null.");
       }
     }
-    return -1;
+    return timeoutMs;
   }
 
   public int getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds() {
     Map<String, Object> clusterConfMap = getClusterConfMap();
+    int timeoutMs = -1;
     if (clusterConfMap.containsKey(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY)) {
       Object timeoutObject = clusterConfMap.get(ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY);
       if (timeoutObject != null) {
-        int timeoutMs = Integer.valueOf((String) timeoutObject);
-        logger.log(Level.INFO,
-                "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
-        return timeoutMs;
+        if (timeoutObject instanceof String) {
+          timeoutMs = Integer.valueOf((String) timeoutObject);
+          logger.log(Level.INFO,
+                  "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        } else if (timeoutObject instanceof Integer) {
+          timeoutMs = (int) timeoutObject;
+          logger.log(Level.INFO,
+                  "getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds returns timeout value: " + timeoutMs);
+        } else {
+          logger.log(Level.WARNING,
+                  ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is unacceptable type.");
+        }
       } else {
         logger.log(Level.WARNING,
                 ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY + " value is null.");
       }
     }
-    return -1;
+    return timeoutMs;
   }
 }

--- a/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
@@ -12,7 +12,12 @@ import static org.junit.Assert.assertEquals;
 public class KafkaClusterTest {
 
     private static final Map<String, Object> EMPTY_MAP = new HashMap<>();
-    private static final Map<String, String> RESULT_MAP = new HashMap<String, String>() {{
+    private static final Map<String, Integer> RESULT_INT_MAP = new HashMap<String, Integer>() {{
+        put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY, 11111);
+        put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY, 22222);
+        put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY, 33333);
+    }};
+    private static final Map<String, String> RESULT_STRING_MAP = new HashMap<String, String>() {{
         put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY, "11111");
         put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY, "22222");
         put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY, "33333");
@@ -31,7 +36,9 @@ public class KafkaClusterTest {
         cluster.setAttribute(cluster.ATTR_CONF_KEY, EMPTY_MAP);
         assertEquals(-1, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
         // Cluster has cluster admin client timeout attribute
-        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_MAP);
+        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_INT_MAP);
+        assertEquals(11111, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
+        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_STRING_MAP);
         assertEquals(11111, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
     }
 
@@ -48,7 +55,9 @@ public class KafkaClusterTest {
         cluster.setAttribute(cluster.ATTR_CONF_KEY, EMPTY_MAP);
         assertEquals(-1, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
         // Cluster has topic admin client timeout attribute
-        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_MAP);
+        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_INT_MAP);
+        assertEquals(22222, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
+        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_STRING_MAP);
         assertEquals(22222, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
     }
 
@@ -65,7 +74,9 @@ public class KafkaClusterTest {
         cluster.setAttribute(cluster.ATTR_CONF_KEY, EMPTY_MAP);
         assertEquals(-1, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
         // Cluster has consumer group admin client timeout attribute
-        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_MAP);
+        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_INT_MAP);
+        assertEquals(33333, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
+        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_STRING_MAP);
         assertEquals(33333, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
     }
 }

--- a/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
@@ -17,11 +17,6 @@ public class KafkaClusterTest {
         put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY, 22222);
         put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY, 33333);
     }};
-    private static final Map<String, String> RESULT_STRING_MAP = new HashMap<String, String>() {{
-        put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_CLUSTER_REQUEST_TIMEOUT_MILLISECONDS_KEY, "11111");
-        put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_TOPIC_REQUEST_TIMEOUT_MILLISECONDS_KEY, "22222");
-        put(KafkaCluster.ATTR_KAFKA_ADMIN_CLIENT_CONSUMER_GROUP_REQUEST_TIMEOUT_MILLISECONDS_KEY, "33333");
-    }};
 
     @Test
     public void testGetKafkaAdminClientClusterRequestTimeoutMilliseconds() throws Exception {
@@ -37,8 +32,6 @@ public class KafkaClusterTest {
         assertEquals(-1, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
         // Cluster has cluster admin client timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_INT_MAP);
-        assertEquals(11111, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
-        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_STRING_MAP);
         assertEquals(11111, cluster.getKafkaAdminClientClusterRequestTimeoutMilliseconds());
     }
 
@@ -57,8 +50,6 @@ public class KafkaClusterTest {
         // Cluster has topic admin client timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_INT_MAP);
         assertEquals(22222, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
-        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_STRING_MAP);
-        assertEquals(22222, cluster.getKafkaAdminClientTopicRequestTimeoutMilliseconds());
     }
 
     @Test
@@ -75,8 +66,6 @@ public class KafkaClusterTest {
         assertEquals(-1, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
         // Cluster has consumer group admin client timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_INT_MAP);
-        assertEquals(33333, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
-        cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_STRING_MAP);
         assertEquals(33333, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
     }
 }


### PR DESCRIPTION
Yaml file can be loaded config as int. Add type check and int handling logic. 