### PR TITLE
Slack notification feature

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
@@ -122,8 +122,7 @@ public class ActionNotificationHelper {
         if (isSendingSlackNotification) {
             sendSlackNotifications();
         } else {
-            getLogger().log(
-                    Level.INFO, "ActionNotificationHelper does not send any notification.");
+            getLogger().log(Level.INFO, "ActionNotificationHelper does not send any notification.");
         }
     }
 }

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
@@ -112,7 +112,6 @@ public class ActionNotificationHelper {
         );
         try {
             getAction().getEngine().alert(slackAlert, slackAlertMessage);
-            getLogger().log(Level.INFO, "ActionNotificationHelper has sent slack notifications.");
         } catch (Exception e) {
             getLogger().log(Level.WARNING, "ActionNotificationHelper fails to send Slack message: " + e);
         }
@@ -121,8 +120,6 @@ public class ActionNotificationHelper {
     public void sendNotifications() {
         if (isSendingSlackNotification) {
             sendSlackNotifications();
-        } else {
-            getLogger().log(Level.INFO, "ActionNotificationHelper does not send any notification.");
         }
     }
 }

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
@@ -122,7 +122,7 @@ public class ActionNotificationHelper {
         if (isSendingSlackNotification) {
             sendSlackNotifications();
         } else {
-            getAction().logger().log(
+            getLogger().log(
                     Level.INFO, "ActionNotificationHelper does not send any notification.");
         }
     }

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
@@ -118,7 +118,7 @@ public class ActionNotificationHelper {
         }
     }
 
-    public void sendNotification() {
+    public void sendNotifications() {
         if (isSendingSlackNotification) {
             sendSlackNotifications();
         } else {

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelper.java
@@ -1,0 +1,129 @@
+package com.pinterest.orion.core.actions.alert;
+
+import com.pinterest.orion.core.actions.Action;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+
+import javax.ws.rs.client.WebTarget;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ActionNotificationHelper {
+
+    public static final String ATTR_SLACK_WEBHOOK_URL_LIST_KEY = "slackWebhookUrlList";
+    private Action action;
+    private String alertTitle;
+    private String alertMessage;
+    private boolean isSendingSlackNotification = false;
+    private List<String> slackWebhookUrlList;
+    private Logger logger;
+
+    public ActionNotificationHelper(Action action, Map<String, Object> config) {
+        // Use action and its config to construct ActionNotificationHelper.
+        setAction(action);
+        setAlertTitle(action.getName());
+        setAlertMessage(action.getName());
+        setLogger(action.logger());
+        // Config determines which types of notification will be sent. Can add more types of notifications here.
+        if (config.containsKey(ATTR_SLACK_WEBHOOK_URL_LIST_KEY)) {
+            Object slackWebhookUrlListObject = config.get(ATTR_SLACK_WEBHOOK_URL_LIST_KEY);
+            if (slackWebhookUrlListObject != null) {
+                if (slackWebhookUrlListObject instanceof List) {
+                    this.isSendingSlackNotification = true;
+                    this.slackWebhookUrlList = (List<String>) config.get(ATTR_SLACK_WEBHOOK_URL_LIST_KEY);
+                } else {
+                    // Log warn if slackWebhookUrlList cannot be parsed from config.
+                    getLogger().log(Level.WARNING, ATTR_SLACK_WEBHOOK_URL_LIST_KEY + " value is unacceptable type.");
+                }
+            } else {
+                getLogger().log(Level.WARNING, ATTR_SLACK_WEBHOOK_URL_LIST_KEY + " value is null.");
+            }
+        }
+    }
+
+    public void setAction(Action action) {
+        this.action = action;
+    }
+
+    public void setAlertTitle(String alertTitle) {
+        // Call this in Action class if you need personalized alert title.
+        this.alertTitle = alertTitle;
+    }
+
+    public void setAlertMessage(String alertMessage) {
+        // Call this in Action class if you need personalized alert message.
+        this.alertMessage = alertMessage;
+    }
+
+    public void setLogger(Logger logger) {
+        // Use logger from action. If action does not have logger, create one.
+        if (logger != null) {
+            this.logger = logger;
+        } else {
+            this.logger = Logger.getLogger(this.getClass().getName());
+        }
+    }
+
+    public Action getAction() {
+        return this.action;
+    }
+
+    public String getAlertTitle(){
+        return this.alertTitle;
+    }
+
+    public String getAlertMessage() {
+        return this.alertMessage;
+    }
+
+    public Logger getLogger() {
+        return this.logger;
+    }
+
+    public List<String> getSlackWebhookUrlList() {
+        return this.slackWebhookUrlList;
+    }
+
+    protected static List<WebTarget> getWebTargetsFromWebhookUrlList(List<String> webhookUrlList) {
+        // Transfer webhook urls (String) to web targets (WebTarget)
+        List<WebTarget> webTargets = new ArrayList<>();
+        for (int i = 0; i < webhookUrlList.size(); i++) {
+            WebTarget webTarget = JerseyClientBuilder.newClient().target(webhookUrlList.get(i));
+            webTargets.add(webTarget);
+        }
+        return webTargets;
+    }
+
+    private void sendSlackNotifications() {
+        SlackAlert slackAlert = new SlackAlert();
+        try {
+            List<WebTarget> webTargets = getWebTargetsFromWebhookUrlList(getSlackWebhookUrlList());
+            slackAlert.setWebTargets(webTargets);
+        } catch (Exception e) {
+            getLogger().log(Level.WARNING, "ActionNotificationHelper fails to get web targets: " + e);
+            return;
+        }
+        AlertMessage slackAlertMessage = new AlertMessage(
+                getAlertTitle(),
+                getAlertMessage(),
+                getAction().getOwner()
+        );
+        try {
+            getAction().getEngine().alert(slackAlert, slackAlertMessage);
+            getLogger().log(Level.INFO, "ActionNotificationHelper has sent slack notifications.");
+        } catch (Exception e) {
+            getLogger().log(Level.WARNING, "ActionNotificationHelper fails to send Slack message: " + e);
+        }
+    }
+
+    public void sendNotification() {
+        if (isSendingSlackNotification) {
+            sendSlackNotifications();
+        } else {
+            getAction().logger().log(
+                    Level.INFO, "ActionNotificationHelper does not send any notification.");
+        }
+    }
+}

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
@@ -120,7 +120,7 @@ public class ReplaceEC2InstanceAction extends NodeAction {
     }
 
     // Send notifications
-    notificationHelper.sendNotification();
+    notificationHelper.sendNotifications();
 
     // put the node into maintenance mode if node exists in the clusterMap
     boolean prevMaintenanceMode = false;

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
@@ -17,6 +17,7 @@ package com.pinterest.orion.core.actions.aws;
 
 import com.pinterest.orion.core.Attribute;
 import com.pinterest.orion.core.PluginConfigurationException;
+import com.pinterest.orion.core.actions.alert.ActionNotificationHelper;
 import com.pinterest.orion.core.actions.alert.AlertLevel;
 import com.pinterest.orion.core.actions.alert.AlertMessage;
 import com.pinterest.orion.core.actions.generic.NodeAction;
@@ -62,6 +63,7 @@ public class ReplaceEC2InstanceAction extends NodeAction {
   private String hostname;
   private String instanceId;
   private Map<String, List<String>> fallbacksMap = new HashMap<>();
+  private ActionNotificationHelper notificationHelper;
   protected boolean skipClusterHealthCheck = false;
 
   @Override
@@ -78,6 +80,7 @@ public class ReplaceEC2InstanceAction extends NodeAction {
     if (config.containsKey(ATTR_FALLBACK_MAPPING)) {
       fallbacksMap = (Map<String, List<String>>)config.get(ATTR_FALLBACK_MAPPING);
     }
+    notificationHelper = new ActionNotificationHelper(this, config);
     confRoute53ZoneId = config.get(Ec2Utils.CONF_ROUTE53_ZONE_ID).toString();
     confRoute53Name = config.get(Ec2Utils.CONF_ROUTE53_ZONE_NAME).toString();
     setAttribute(RECOVERY_TIMEOUT, 3600_000);
@@ -115,6 +118,9 @@ public class ReplaceEC2InstanceAction extends NodeAction {
           .appendOut("Cause of replacement: " + cause + "\n");
       metricPrefix.tagged("cause", cause);
     }
+
+    // Send notifications
+    notificationHelper.sendNotification();
 
     // put the node into maintenance mode if node exists in the clusterMap
     boolean prevMaintenanceMode = false;

--- a/orion-server/src/test/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelperTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelperTest.java
@@ -1,0 +1,76 @@
+package com.pinterest.orion.core.actions.alert;
+
+import com.pinterest.orion.core.actions.Action;
+import com.pinterest.orion.core.actions.ActionEngine;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ActionNotificationHelperTest {
+
+    @Test
+    public void testNoNotification() throws Exception {
+        Action action = Mockito.mock(Action.class);
+        Logger logger = Mockito.mock(Logger.class);
+        ActionEngine engine =  Mockito.mock(ActionEngine.class);
+        // Mock action
+        Mockito.when(action.logger()).thenReturn(logger);
+        Mockito.when(action.getEngine()).thenReturn(engine);
+        // Create a config
+        Map<String, Object> emptyConfig = new HashMap<>();
+        // Create notification helper from mock action and config
+        ActionNotificationHelper notificationHelper = new ActionNotificationHelper(
+                action, emptyConfig
+        );
+        // Validate sendNotification method
+        notificationHelper.sendNotification();
+        verify(action, times(0)).getEngine();
+    }
+
+    @Test
+    public void testSendSlackNotification() throws Exception {
+        Action action = Mockito.mock(Action.class);
+        Logger logger = Mockito.mock(Logger.class);
+        ActionEngine engine =  Mockito.mock(ActionEngine.class);
+        // Mock action
+        Mockito.when(action.logger()).thenReturn(logger);
+        Mockito.when(action.getEngine()).thenReturn(engine);
+        Mockito.when(action.getOwner()).thenReturn("test_owner");
+        // Create a config
+        List<String> testWebhookUrlList = new ArrayList<String>() {{
+            add("test_webhook_url");
+        }};
+        Map<String, Object> config = new HashMap<String, Object>(){{
+            put(ActionNotificationHelper.ATTR_SLACK_WEBHOOK_URL_LIST_KEY, testWebhookUrlList);
+        }};
+        // Create notification helper from mock action and config
+        ActionNotificationHelper notificationHelper = new ActionNotificationHelper(
+                action, config
+        );
+        // Test parameters
+        notificationHelper.setAlertTitle("test_title");
+        notificationHelper.setAlertMessage("test_message");
+        assertEquals(testWebhookUrlList, notificationHelper.getSlackWebhookUrlList());
+        // Create alerts and alert message
+        AlertMessage testSlackAlertMessage = new AlertMessage(
+                "test_title",
+                "test_message",
+                "test_owner"
+        );
+        SlackAlert testSlackAlert = new SlackAlert();
+        testSlackAlert.setWebTargets(ActionNotificationHelper.getWebTargetsFromWebhookUrlList(testWebhookUrlList));
+        // Validate sendNotification method
+        notificationHelper.sendNotification();
+        verify(action, times(1)).getEngine();
+        verify(engine, times(1)).alert(testSlackAlert, testSlackAlertMessage);
+    }
+}

--- a/orion-server/src/test/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelperTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelperTest.java
@@ -31,8 +31,8 @@ public class ActionNotificationHelperTest {
         ActionNotificationHelper notificationHelper = new ActionNotificationHelper(
                 action, emptyConfig
         );
-        // Validate sendNotification method
-        notificationHelper.sendNotification();
+        // Validate sendNotifications method
+        notificationHelper.sendNotifications();
         verify(action, times(0)).getEngine();
     }
 
@@ -68,8 +68,8 @@ public class ActionNotificationHelperTest {
         );
         SlackAlert testSlackAlert = new SlackAlert();
         testSlackAlert.setWebTargets(ActionNotificationHelper.getWebTargetsFromWebhookUrlList(testWebhookUrlList));
-        // Validate sendNotification method
-        notificationHelper.sendNotification();
+        // Validate sendNotifications method
+        notificationHelper.sendNotifications();
         verify(action, times(1)).getEngine();
         verify(engine, times(1)).alert(testSlackAlert, testSlackAlertMessage);
     }


### PR DESCRIPTION
ActionNotificationHelper is used by Action class to send notifications in Orion. It supports Slack for its first version but can be extended to other type of messages (ex. page_duty). 

For each action, the helper is created in initialization with action itself and config. Based on the config, the helper will decide whether to send notifications and what's its destinations. If the config does not have required parameters, nothing will happen. 

When the message needs to be sent, simply call notificationHelper.sendNotifications();

Sample config 
```
  - clusterId: test_kafka_cluster
    type: kafka
    configuration:
      slackWebhookUrlList: 
          - {url_1}
          - {url_2}
```
Sample usage
* See orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
