### PR TITLE
Update ActionNotificationHelper logic; Add pre-defined notification message in ReplaceEC2InstanceAction

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
@@ -120,7 +120,12 @@ public class ReplaceEC2InstanceAction extends NodeAction {
     }
 
     // Send notifications
-    notificationHelper.sendNotifications();
+    if (notificationHelper.isSendingNotifications()) {
+      notificationHelper.setAlertTitle("Executing ReplaceEC2InstanceAction on " + getEngine().getCluster().getClusterId());
+      notificationHelper.setAlertMessage("Action name: " + this.getName()); // Name is from the child action.
+      notificationHelper.setAlertOwner(this.getOwner());
+      notificationHelper.sendNotifications();
+    }
 
     // put the node into maintenance mode if node exists in the clusterMap
     boolean prevMaintenanceMode = false;

--- a/orion-server/src/test/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelperTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/actions/alert/ActionNotificationHelperTest.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -33,7 +35,8 @@ public class ActionNotificationHelperTest {
         );
         // Validate sendNotifications method
         notificationHelper.sendNotifications();
-        verify(action, times(0)).getEngine();
+        assertFalse(notificationHelper.isSendingNotifications());
+        verify(action, times(1)).getEngine(); // just non-null check, no execution
     }
 
     @Test
@@ -69,8 +72,9 @@ public class ActionNotificationHelperTest {
         SlackAlert testSlackAlert = new SlackAlert();
         testSlackAlert.setWebTargets(ActionNotificationHelper.getWebTargetsFromWebhookUrlList(testWebhookUrlList));
         // Validate sendNotifications method
+        assertTrue(notificationHelper.isSendingNotifications());
         notificationHelper.sendNotifications();
-        verify(action, times(1)).getEngine();
+        verify(action, times(2)).getEngine(); // non-null check and execution
         verify(engine, times(1)).alert(testSlackAlert, testSlackAlertMessage);
     }
 


### PR DESCRIPTION
Update ActionNotificationHelper logic 
* Allow to set owner
* Remove get title/message from initialization. 
* Add get engine non-null check. The engine is not ready while initializing the action.

Add pre-defined notification message in ReplaceEC2InstanceAction
* getName in action class is not that good. Use predefined messages. 
* Use isSendingNotifications to check whether to send messages. Then add personalized messages. 