### PR TITLE
Load metrics call timeout value from config

### DIFF
--- a/orion-agent/src/main/java/com/pinterest/orion/agent/BaseAgent.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/BaseAgent.java
@@ -122,7 +122,7 @@ public abstract class BaseAgent {
       metricFutures.add(MetricsRetriever.getMetric(task));
     }
     for (Future<Metric> metricFuture : metricFutures) {
-      Metric metric = metricFuture.get(10, TimeUnit.SECONDS);
+      Metric metric = metricFuture.get(getConfig().getMetricsCallTimeoutSec(), TimeUnit.SECONDS);
       metrics.addToMetrics(metric);
     }
     return metrics;

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/OrionAgentConfig.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/OrionAgentConfig.java
@@ -102,6 +102,10 @@ public class OrionAgentConfig {
     return Long.parseLong(agentConfigs.getOrDefault("pollInterval", "5000"));
   }
 
+  public long getMetricsCallTimeoutSec() {
+    return Long.parseLong(agentConfigs.getOrDefault("metricsCallTimeoutSecond", "10"));
+  }
+
   public long getMetricsPollInterval() {
     return Long.parseLong(agentConfigs.getOrDefault("metricsPollInterval", "30000"));
   }


### PR DESCRIPTION
Load metrics call timeout value from config to avoid timeout error while calling metricFuture.get

The agent needs config for initialization so the getConfig wont return a null value. 

