### PR TITLE
Add topic set cache to reduce the number of calls of adminClient.listTopics

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ReassignmentAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ReassignmentAction.java
@@ -50,7 +50,7 @@ public class ReassignmentAction extends AbstractKafkaAction {
     long metadataFetchTimeoutMs = KafkaCluster.DEFAULT_METADATA_TIMEOUT_MS; // default
     Attribute attribute = getAttribute(ATTR_REASSIGNMENT_KEY);
     Attribute metadataFetchTimeoutMsAttr = getAttribute(KafkaIdealBalanceAction.CONF_METADATA_FETCH_TIMEOUT_MS_KEY);
-    KafkaCluster kakfaCluster = (KafkaCluster) getEngine().getCluster();
+    KafkaCluster kafkaCluster = (KafkaCluster) getEngine().getCluster();
     if (metadataFetchTimeoutMsAttr != null) {
       metadataFetchTimeoutMs = metadataFetchTimeoutMsAttr.getValue();
     }
@@ -78,8 +78,8 @@ public class ReassignmentAction extends AbstractKafkaAction {
         }
 
         zkClient.create().forPath(REASSIGNMENT_PATH, assignmentJson.getBytes());
-        waitForISRsToMatchAssignments(kakfaCluster, assignmentMap, 15_000, metadataFetchTimeoutMs);
-        waitForURPsToBeResolved(kakfaCluster, 15_000);
+        waitForISRsToMatchAssignments(kafkaCluster, assignmentMap, 15_000, metadataFetchTimeoutMs);
+        waitForURPsToBeResolved(kafkaCluster, 15_000);
         CuratorClient.waitForZnodeToBeDeleted(zkClient, REASSIGNMENT_PATH);
         markSucceeded();
       } catch (Exception e) {

--- a/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/kafka/KafkaClusterTest.java
@@ -1,12 +1,22 @@
 package com.pinterest.orion.core.kafka;
 
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.common.KafkaFuture;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 
 public class KafkaClusterTest {
@@ -67,5 +77,36 @@ public class KafkaClusterTest {
         // Cluster has consumer group admin client timeout attribute
         cluster.setAttribute(cluster.ATTR_CONF_KEY, RESULT_INT_MAP);
         assertEquals(33333, cluster.getKafkaAdminClientConsumerGroupRequestTimeoutMilliseconds());
+    }
+
+    @Test
+    public void testKafkaClusterCachedTopicSetLogic() throws Exception {
+        KafkaCluster cluster = new KafkaCluster("", "", Collections.emptyList(),
+                Collections.emptyList(), null, null, null, null, null);
+        // Mock all components in listTopics call path
+        AdminClient adminClient = Mockito.mock(AdminClient.class);
+        ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
+        KafkaFuture<Set<String>> kafkaFuture = mock(KafkaFuture.class);
+        Set<String> topicSet = Collections.emptySet();
+        Mockito.when(kafkaFuture.get(12345, TimeUnit.MILLISECONDS)).thenReturn(topicSet);
+        Mockito.when(listTopicsResult.names()).thenReturn(kafkaFuture);
+        Mockito.when(adminClient.listTopics(any())).thenReturn(listTopicsResult);
+        cluster.setAdminClient(adminClient);
+        cluster.setClusterId("Test_Cluster");
+        // Initial call. adminClient.listTopics is triggered
+        cluster.getKafkaTopicSet(12345);
+        verify(adminClient, times(1)).listTopics(any());
+        // Set an extremely large interval. adminClient.listTopics is not triggered
+        cluster.setCachedTopicSetRefreshIntervalMill(3600_000L); // 1 hour
+        cluster.getKafkaTopicSet(12345);
+        verify(adminClient, times(1)).listTopics(any());
+        // Reset lastUpdateTime. adminClient.listTopics is forced to be triggered
+        cluster.resetCachedTopicSetLastUpdateTime();
+        cluster.getKafkaTopicSet(12345);
+        verify(adminClient, times(2)).listTopics(any());
+        // Reach TTL by setting an extremely low interval. adminClient.listTopics is triggered
+        cluster.setCachedTopicSetRefreshIntervalMill(0);
+        cluster.getKafkaTopicSet(12345);
+        verify(adminClient, times(3)).listTopics(any());
     }
 }


### PR DESCRIPTION
### Issue 

ReassignmentAction reports error frequently. One reason is AdminClient meta data call was triggered many times. There's a while loop for health check.  
```
while (!cluster.clusterHealthy())
```
In the method, it gets all topics and checks all topics. 
```
adminClient.listTopics
```
This api call is a meta data call. Since it's in a while loop, there are many calls triggered. Since it's a while loop check, the interval between two checks cannot be too long.

In KafkaCluste class, there's a static method called 
```
getTopicDescriptions
```
It used at many places that adminClient was passed in while a topic description map is passed out. The method has two parts: list topic and describe topic. 

Describe topic result can be changed frequently, but the list topic results are usually static unless we add new topics. We can cache the list topic results to reduce the number of meta data call. 

### Idea
* I split the big getTopicDescriptions method into two static methods: list topic (a1) and describe topic (b). 
* If the caller is from outside classes (like memq sensor), it's using a1+b. 
* If the caller can use topic set cache, I have a non-static method checking cache first (a2). The call path is a2+b. 

getKafkaTopicSetFromAttribute is also extracted from the original call path 

The API schema is not changed at all. No need to make change at caller side. 

Plus a typo fix kakfa -> kafka

### Test
* Unit test for cache logic. 
* Canary host deployment