### PR TITLE
Add configurable timeout value for agent describe cluster call 

### DIFF
--- a/orion-agent/src/main/java/com/pinterest/orion/agent/OrionAgentConfig.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/OrionAgentConfig.java
@@ -106,6 +106,10 @@ public class OrionAgentConfig {
     return Long.parseLong(agentConfigs.getOrDefault("metricsCallTimeoutSecond", "10"));
   }
 
+  public int getDescribeClusterTimeoutMs() {
+    return Integer.parseInt(agentConfigs.getOrDefault("describeClusterTimeoutMs", "10000"));
+  }
+
   public long getMetricsPollInterval() {
     return Long.parseLong(agentConfigs.getOrDefault("metricsPollInterval", "30000"));
   }

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/kafka/KafkaAgent.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/kafka/KafkaAgent.java
@@ -196,8 +196,11 @@ public class KafkaAgent extends BaseAgent {
       props.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, localBootstrapServerAddress);
       heartbeatAdminClient = AdminClient.create(props);
       Future<Long> kafkaUptimeFuture = getKafkaUptime();
-      DescribeClusterResult result = heartbeatAdminClient.describeCluster();
-      result.clusterId().get(KAFKA_CLIENT_TIMEOUT_SEC, TimeUnit.SECONDS);
+      int describeClusterTimeoutMs = config.getDescribeClusterTimeoutMs();
+      DescribeClusterResult result = heartbeatAdminClient.describeCluster(
+              new DescribeClusterOptions().timeoutMs(describeClusterTimeoutMs)
+      );
+      result.clusterId().get(describeClusterTimeoutMs, TimeUnit.MILLISECONDS);
       status.setUptime(kafkaUptimeFuture.get(3, TimeUnit.SECONDS));
       logger.info("Kafka uptime: " + kafkaUptimeFuture.get());
       status.setStatusType(StatusType.OK);

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -218,7 +218,7 @@ public class KafkaCluster extends Cluster {
                                                                   clusterId,
                                                                   metadataFetchTimeoutMs);
     // Set the topic cache is the cache does not exist. This cache can be refreshed by KafkaTopicSensor.
-    if (!containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY) || ret != null) {
+    if (!containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY)) {
       setAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY, ret);
     }
     return ret;

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -218,7 +218,7 @@ public class KafkaCluster extends Cluster {
                                                                   clusterId,
                                                                   metadataFetchTimeoutMs);
     // Set the topic cache is the cache does not exist. This cache can be refreshed by KafkaTopicSensor.
-    if (!containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY)) {
+    if (!containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY) || ret != null) {
       setAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY, ret);
     }
     return ret;

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -217,6 +217,10 @@ public class KafkaCluster extends Cluster {
                                                                   cachedTopicMap,
                                                                   clusterId,
                                                                   metadataFetchTimeoutMs);
+    // Set the topic cache is the cache does not exist. This cache can be refreshed by KafkaTopicSensor.
+    if (!containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY)) {
+      setAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY, ret);
+    }
     return ret;
   }
 

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -217,10 +217,6 @@ public class KafkaCluster extends Cluster {
                                                                   cachedTopicMap,
                                                                   clusterId,
                                                                   metadataFetchTimeoutMs);
-    // Set the topic cache is the cache does not exist. This cache can be refreshed by KafkaTopicSensor.
-    if (!containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY)) {
-      setAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY, ret);
-    }
     return ret;
   }
 


### PR DESCRIPTION
### Agent Fix

Make the timeout value used in describeCluster configurable. This should fix the common timeout issue of getServiceStatus method in orion agent.

I make the AdminClient.describeCluster and future.get function sharing the same timeout value to reduce the ambiguity. 

The config key is describeClusterTimeoutMs. The value is milliseconds (because DescribeClusterOptions takes Ms). Default value was set to 10 sec (10000 ms). 

