### PR TITLE
Allow KafkaCluster to initialize topic info cache if the cache does not exist

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java
@@ -217,6 +217,11 @@ public class KafkaCluster extends Cluster {
                                                                   cachedTopicMap,
                                                                   clusterId,
                                                                   metadataFetchTimeoutMs);
+    // Set the topic cache if the cache has not been created by KafkaTopicSensor.
+    // It will be refreshed by KafkaTopicSensor.
+    if (!containsAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY) && ret != null) {
+      setAttribute(KafkaTopicSensor.ATTR_TOPICINFO_MAP_KEY, ret);
+    }
     return ret;
   }
 


### PR DESCRIPTION
Topic sensor can cache topic info but reassignment action cannot do that. I add a cache logic in KafkaCluster class. If the cache has not been created yet (no attribute), just initialize it. This should benefit the while loop check in reassignment action. The cache can still be updated by topic sensor