### PR TITLE
Fix java.lang.ClassCastException bug

### DIFF
--- a/deployments/orion-agent-deployment/pom.xml
+++ b/deployments/orion-agent-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.36</version>
+		<version>0.0.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent-deployment</artifactId>

--- a/deployments/orion-server-deployment/pom.xml
+++ b/deployments/orion-server-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.36</version>
+		<version>0.0.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server-deployment</artifactId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.36</version>
+		<version>0.0.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>deployments</artifactId>

--- a/orion-agent/pom.xml
+++ b/orion-agent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.36</version>
+		<version>0.0.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent</artifactId>

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
@@ -118,7 +118,7 @@ public class MetricUtils {
       MetricName name = gaugeEntry.getKey();
       Gauge entryValue = gaugeEntry.getValue();
       Metric converted = new Metric();
-      Value val = new Value(MetricType.GAUGE, name.getKey(), (long) entryValue.getValue());
+      Value val = new Value(MetricType.GAUGE, name.getKey(), (new Double((double) entryValue.getValue())).longValue());
       converted.setValues(Collections.singletonList(val));
       converted.setTags(name.getTags());
       converted.setSeries(name.getKey());

--- a/orion-commons/pom.xml
+++ b/orion-commons/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.36</version>
+		<version>0.0.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-commons</artifactId>

--- a/orion-server/pom.xml
+++ b/orion-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.36</version>
+		<version>0.0.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.orion</groupId>
 	<artifactId>orion-parent</artifactId>
-	<version>0.0.36</version>
+	<version>0.0.37</version>
 	<name>orion</name>
 	<packaging>pom</packaging>
 	<description>Orion is a generalized plugable management and automation platform for stateful distributed systems</description>


### PR DESCRIPTION
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Long 

At MetricUtils.java:121

Use Double.longValue() to convert the double value into long instead of directly call "(long)"