### PR TITLE
Add try-catch and conversion logic to avoid ClassCastException in convertGauges

### DIFF
--- a/deployments/orion-agent-deployment/pom.xml
+++ b/deployments/orion-agent-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.38</version>
+		<version>0.0.39</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent-deployment</artifactId>

--- a/deployments/orion-server-deployment/pom.xml
+++ b/deployments/orion-server-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.38</version>
+		<version>0.0.39</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server-deployment</artifactId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.38</version>
+		<version>0.0.39</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>deployments</artifactId>

--- a/orion-agent/pom.xml
+++ b/orion-agent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.38</version>
+		<version>0.0.39</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent</artifactId>

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
@@ -31,6 +31,7 @@ import com.pinterest.orion.agent.BaseAgent;
 import com.pinterest.orion.agent.metrics.JMXMetricRetreiverTask;
 import com.pinterest.orion.agent.metrics.MetricDefinition;
 import com.pinterest.orion.agent.metrics.MetricRetrieverTask;
+import com.sun.tools.javac.main.Option;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
@@ -118,12 +119,38 @@ public class MetricUtils {
       MetricName name = gaugeEntry.getKey();
       Gauge entryValue = gaugeEntry.getValue();
       Metric converted = new Metric();
-      Value val = new Value(MetricType.GAUGE, name.getKey(), (long) entryValue.getValue());
+      Value val;
+      try {
+        val = new Value(MetricType.GAUGE, name.getKey(), getGaugesEntryValueNumber(entryValue.getValue()));
+      } catch (NumberFormatException|NullPointerException e) {
+        // Skip if the conversion fails.
+        logger.log(Level.WARNING,"MetricUtils convertGauges fails: ", e);
+        continue;
+      }
       converted.setValues(Collections.singletonList(val));
       converted.setTags(name.getTags());
       converted.setSeries(name.getKey());
       converted.setTimestamp(timestamp);
       toConvert.addToMetrics(converted);
+    }
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static double getGaugesEntryValueNumber(Object entryValueNumberObject)
+          throws NumberFormatException, NullPointerException {
+    // Convert all types of entryValueNumberObject into double to avoid ClassCastException from conversion
+    if (entryValueNumberObject == null) {
+      throw new NullPointerException("Gauge entryValue has empty value");
+    } else if (entryValueNumberObject instanceof Double) {
+      return ((Double) entryValueNumberObject).doubleValue();
+    } else if (entryValueNumberObject instanceof Long) {
+      return ((Long) entryValueNumberObject).doubleValue();
+    } else if (entryValueNumberObject instanceof Integer) {
+      return ((Integer) entryValueNumberObject).doubleValue();
+    } else {
+      // Handle String object or all other cases.
+      // NumberFormatException will be thrown if parsing fails.
+      return Double.parseDouble(entryValueNumberObject.toString());
     }
   }
 

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
@@ -31,7 +31,6 @@ import com.pinterest.orion.agent.BaseAgent;
 import com.pinterest.orion.agent.metrics.JMXMetricRetreiverTask;
 import com.pinterest.orion.agent.metrics.MetricDefinition;
 import com.pinterest.orion.agent.metrics.MetricRetrieverTask;
-import com.sun.tools.javac.main.Option;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;

--- a/orion-commons/pom.xml
+++ b/orion-commons/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.38</version>
+		<version>0.0.39</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-commons</artifactId>

--- a/orion-server/pom.xml
+++ b/orion-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.38</version>
+		<version>0.0.39</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.orion</groupId>
 	<artifactId>orion-parent</artifactId>
-	<version>0.0.38</version>
+	<version>0.0.39</version>
 	<name>orion</name>
 	<packaging>pom</packaging>
 	<description>Orion is a generalized plugable management and automation platform for stateful distributed systems</description>


### PR DESCRIPTION
Add try-catch and conversion logic to avoid ClassCastException in convertGauges

getGaugesEntryValueNumber should be able to handle all types of Object. If the object is null or cannot be parsed as a string, it will throw exception so the outer for loop will just continue to the next one. 

Upgrade to 0.0.39 for orion agent deployment 