### PR TITLE
Add try-catch and conversion logic to avoid ClassCastException in convertCounters

### DIFF
--- a/deployments/orion-agent-deployment/pom.xml
+++ b/deployments/orion-agent-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.39</version>
+		<version>0.0.40</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent-deployment</artifactId>

--- a/deployments/orion-server-deployment/pom.xml
+++ b/deployments/orion-server-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.39</version>
+		<version>0.0.40</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server-deployment</artifactId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.39</version>
+		<version>0.0.40</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>deployments</artifactId>

--- a/orion-agent/pom.xml
+++ b/orion-agent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.39</version>
+		<version>0.0.40</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent</artifactId>

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
@@ -158,7 +158,13 @@ public class MetricUtils {
       MetricName name = counterEntry.getKey();
       Counter entryValue = counterEntry.getValue();
       Metric converted = new Metric();
-      Value val = new Value(MetricType.COUNTER, name.getKey(), entryValue.getCount());
+      Value val;
+      try {
+        val = new Value(MetricType.COUNTER, name.getKey(), getGaugesEntryValueNumber(entryValue.getCount()));
+      } catch (NumberFormatException|NullPointerException e) {
+        logger.log(Level.WARNING,"MetricUtils convertCounters fails: ", e);
+        continue;
+      }
       converted.setValues(Collections.singletonList(val));
       converted.setTags(name.getTags());
       converted.setSeries(name.getKey());

--- a/orion-commons/pom.xml
+++ b/orion-commons/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.39</version>
+		<version>0.0.40</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-commons</artifactId>

--- a/orion-server/pom.xml
+++ b/orion-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.39</version>
+		<version>0.0.40</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.orion</groupId>
 	<artifactId>orion-parent</artifactId>
-	<version>0.0.39</version>
+	<version>0.0.40</version>
 	<name>orion</name>
 	<packaging>pom</packaging>
 	<description>Orion is a generalized plugable management and automation platform for stateful distributed systems</description>


### PR DESCRIPTION
Add try-catch and conversion logic to avoid ClassCastException in convertCounters

The registry with empty gauges can also have empty counters. Need to handle them both. 