### PR TITLE
Change MetricUtils logics: If getGaugesEntryValueNumber fails, dont send partial metrics

### DIFF
--- a/deployments/orion-agent-deployment/pom.xml
+++ b/deployments/orion-agent-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.40</version>
+		<version>0.0.41</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent-deployment</artifactId>

--- a/deployments/orion-server-deployment/pom.xml
+++ b/deployments/orion-server-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.40</version>
+		<version>0.0.41</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server-deployment</artifactId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.40</version>
+		<version>0.0.41</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>deployments</artifactId>

--- a/orion-agent/pom.xml
+++ b/orion-agent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.40</version>
+		<version>0.0.41</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent</artifactId>

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/HeartbeatService.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/HeartbeatService.java
@@ -83,7 +83,13 @@ public class HeartbeatService implements Runnable {
               heartbeat.setMetrics(MetricUtils.convertRegistryToMetrics(OrionAgent.HEARTBEAT_METRICS));
             } catch (Exception e) {
               OrionAgent.TSDB_METRICS.counter("metrics.failed").inc();
-              logger.log(Level.SEVERE, "Failed to fetch metrics: ", e);
+              if (e instanceof NumberFormatException) {
+                logger.log(Level.WARNING,"Failed to fetch metrics due to string entryValue parsing failure: ", e);
+              } else if (e instanceof NullPointerException) {
+                logger.log(Level.WARNING,"Failed to fetch metrics due to null entryValue: ", e);
+              } else {
+                logger.log(Level.SEVERE, "Failed to fetch metrics: ", e);
+              }
               heartbeat.setMetrics(new Metrics());
               heartbeat.setContainsMetrics(true);
             }

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/utils/MetricUtils.java
@@ -113,19 +113,13 @@ public class MetricUtils {
   }
 
   @SuppressWarnings("rawtypes") 
-  private static void convertGauges(Metrics toConvert, SortedMap<MetricName, Gauge> gauges, long timestamp) {
+  private static void convertGauges(Metrics toConvert, SortedMap<MetricName, Gauge> gauges, long timestamp)
+          throws NumberFormatException, NullPointerException {
     for (Map.Entry<MetricName, Gauge> gaugeEntry: gauges.entrySet()) {
       MetricName name = gaugeEntry.getKey();
       Gauge entryValue = gaugeEntry.getValue();
       Metric converted = new Metric();
-      Value val;
-      try {
-        val = new Value(MetricType.GAUGE, name.getKey(), getGaugesEntryValueNumber(entryValue.getValue()));
-      } catch (NumberFormatException|NullPointerException e) {
-        // Skip if the conversion fails.
-        logger.log(Level.WARNING,"MetricUtils convertGauges fails: ", e);
-        continue;
-      }
+      Value val = new Value(MetricType.GAUGE, name.getKey(), getGaugesEntryValueNumber(entryValue.getValue()));
       converted.setValues(Collections.singletonList(val));
       converted.setTags(name.getTags());
       converted.setSeries(name.getKey());
@@ -139,6 +133,7 @@ public class MetricUtils {
           throws NumberFormatException, NullPointerException {
     // Convert all types of entryValueNumberObject into double to avoid ClassCastException from conversion
     if (entryValueNumberObject == null) {
+      logger.log(Level.WARNING,"[MetricUtils] entryValueNumberObject is null");
       throw new NullPointerException("Gauge entryValue has empty value");
     } else if (entryValueNumberObject instanceof Double) {
       return ((Double) entryValueNumberObject).doubleValue();
@@ -153,18 +148,13 @@ public class MetricUtils {
     }
   }
 
-  private static void convertCounters(Metrics toConvert, SortedMap<MetricName, Counter> counters, long timestamp) {
+  private static void convertCounters(Metrics toConvert, SortedMap<MetricName, Counter> counters, long timestamp)
+          throws NumberFormatException, NullPointerException {
     for (Map.Entry<MetricName, Counter> counterEntry: counters.entrySet()) {
       MetricName name = counterEntry.getKey();
       Counter entryValue = counterEntry.getValue();
       Metric converted = new Metric();
-      Value val;
-      try {
-        val = new Value(MetricType.COUNTER, name.getKey(), getGaugesEntryValueNumber(entryValue.getCount()));
-      } catch (NumberFormatException|NullPointerException e) {
-        logger.log(Level.WARNING,"MetricUtils convertCounters fails: ", e);
-        continue;
-      }
+      Value val = new Value(MetricType.COUNTER, name.getKey(), getGaugesEntryValueNumber(entryValue.getCount()));
       converted.setValues(Collections.singletonList(val));
       converted.setTags(name.getTags());
       converted.setSeries(name.getKey());
@@ -173,7 +163,8 @@ public class MetricUtils {
     }
   }
 
-  public static Metrics convertRegistryToMetrics(MetricRegistry registry) {
+  public static Metrics convertRegistryToMetrics(MetricRegistry registry)
+          throws NumberFormatException, NullPointerException {
     Metrics converted = new Metrics();
     long timestamp = System.currentTimeMillis();
     SortedMap<MetricName, Gauge> gauges = registry.getGauges();

--- a/orion-commons/pom.xml
+++ b/orion-commons/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.40</version>
+		<version>0.0.41</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-commons</artifactId>

--- a/orion-server/pom.xml
+++ b/orion-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.40</version>
+		<version>0.0.41</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.orion</groupId>
 	<artifactId>orion-parent</artifactId>
-	<version>0.0.40</version>
+	<version>0.0.41</version>
 	<name>orion</name>
 	<packaging>pom</packaging>
 	<description>Orion is a generalized plugable management and automation platform for stateful distributed systems</description>


### PR DESCRIPTION
Change MetricUtils logics: If getGaugesEntryValueNumber fails, the heartbeat won't contain partial metrics.

I check the agent log. In heartbeat message, if metrics contain partial data, the heartbeat requests are failing. So I just let all exception be handled in registerWithServer instead of skipping individual metrics section with parsing failures. 