### PR TITLE
Keep metrics null instead of setting an empty value

### DIFF
--- a/deployments/orion-agent-deployment/pom.xml
+++ b/deployments/orion-agent-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.41</version>
+		<version>0.0.42</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent-deployment</artifactId>

--- a/deployments/orion-server-deployment/pom.xml
+++ b/deployments/orion-server-deployment/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>deployments</artifactId>
-		<version>0.0.41</version>
+		<version>0.0.42</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server-deployment</artifactId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.41</version>
+		<version>0.0.42</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>deployments</artifactId>

--- a/orion-agent/pom.xml
+++ b/orion-agent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.41</version>
+		<version>0.0.42</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-agent</artifactId>

--- a/orion-agent/src/main/java/com/pinterest/orion/agent/HeartbeatService.java
+++ b/orion-agent/src/main/java/com/pinterest/orion/agent/HeartbeatService.java
@@ -90,8 +90,6 @@ public class HeartbeatService implements Runnable {
               } else {
                 logger.log(Level.SEVERE, "Failed to fetch metrics: ", e);
               }
-              heartbeat.setMetrics(new Metrics());
-              heartbeat.setContainsMetrics(true);
             }
             lastServiceMetricPollTime = now;
           }

--- a/orion-commons/pom.xml
+++ b/orion-commons/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.41</version>
+		<version>0.0.42</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-commons</artifactId>

--- a/orion-server/pom.xml
+++ b/orion-server/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.pinterest.orion</groupId>
 		<artifactId>orion-parent</artifactId>
-		<version>0.0.41</version>
+		<version>0.0.42</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>orion-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.pinterest.orion</groupId>
 	<artifactId>orion-parent</artifactId>
-	<version>0.0.41</version>
+	<version>0.0.42</version>
 	<name>orion</name>
 	<packaging>pom</packaging>
 	<description>Orion is a generalized plugable management and automation platform for stateful distributed systems</description>


### PR DESCRIPTION
I compare two heartbeat json logs, one from agent with URP contains
```
..."metrics":{"metrics":[]},"containsMetrics":true,"readOnly":false}
```

One from agent without error contains
```
..."metrics":null,"containsMetrics":false,"readOnly":false}
```

In this case, I simply keep heartbeat without metrics if getValue fails.  