### PR TITLE
Publish kafka topic metrics including topic size in byte, number of partitions and retention period in ms

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
@@ -148,16 +148,17 @@ public class KafkaTopicSensor extends KafkaSensor {
     // Publish kafka topic metrics including topic size in byte, number of partitions and retention period in ms.
     for (Map.Entry<String, KafkaTopicDescription> entry : topicDescriptionMap.entrySet()) {
       KafkaTopicDescription topicDescription = entry.getValue();
-      String topicName = topicDescription.getName();
+      Map<String, String> metricsTags = new HashMap<String, String>() {{
+        put("topicName", topicDescription.getName());
+        put("isInternal", String.valueOf(topicDescription.isInternal()));
+      }};
       // Topic size
       double topicSize = getTopicSizeByteFromTopicDescription(topicDescription);
       OrionServer.metricsGaugeNum(
               "kafkaTopic",
               "size",
               "byte",
-              new HashMap<String, String>() {{
-                put("topicName", topicName);
-              }},
+              metricsTags,
               topicSize
       );
       // Number of partitions
@@ -166,9 +167,7 @@ public class KafkaTopicSensor extends KafkaSensor {
               "kafkaTopic",
               "partition",
               "num",
-              new HashMap<String, String>() {{
-                put("topicName", topicName);
-              }},
+              metricsTags,
               numPartition
       );
       // Retention
@@ -178,9 +177,7 @@ public class KafkaTopicSensor extends KafkaSensor {
               "kafkaTopic",
               "retention",
               "millisecond",
-              new HashMap<String, String>() {{
-                put("topicName", topicName);
-              }},
+              metricsTags,
               retentionMs
       );
     }

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
@@ -146,8 +146,7 @@ public class KafkaTopicSensor extends KafkaSensor {
 
   public void populateTopicMetrics(Map<String, KafkaTopicDescription> topicDescriptionMap) {
     // Publish kafka topic metrics including topic size in byte, number of partitions and retention period in ms.
-    for (Map.Entry<String, KafkaTopicDescription> entry : topicDescriptionMap.entrySet()) {
-      KafkaTopicDescription topicDescription = entry.getValue();
+    for (KafkaTopicDescription topicDescription : topicDescriptionMap.values()) {
       Map<String, String> metricsTags = new HashMap<String, String>() {{
         put("topicName", topicDescription.getName());
         put("isInternal", String.valueOf(topicDescription.isInternal()));

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
@@ -149,8 +149,6 @@ public class KafkaTopicSensor extends KafkaSensor {
     for (KafkaTopicDescription topicDescription : topicDescriptionMap.values()) {
       Map<String, String> metricsTags = new HashMap<String, String>() {{
         put("topicName", topicDescription.getName());
-        put("isInternal", String.valueOf(topicDescription.isInternal()));
-        put("clusterName", cluster.getName());
         put("clusterId", cluster.getClusterId());
       }};
       // Topic size

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/KafkaTopicSensor.java
@@ -67,7 +67,7 @@ public class KafkaTopicSensor extends KafkaSensor {
       populateTopicBrokersetInfo(assignments, topicDescriptionMap);
       populateTopicLogDirectoryInfo(cluster, topicDescriptionMap);
       populateTopicConfigInfo(adminClient, topicDescriptionMap);
-      populateTopicMetrics(topicDescriptionMap);
+      populateTopicMetrics(cluster, topicDescriptionMap);
 
       setAttribute(cluster, ATTR_TOPICINFO_MAP_KEY, topicDescriptionMap);
 
@@ -144,12 +144,14 @@ public class KafkaTopicSensor extends KafkaSensor {
     return cluster.getTopicDescriptionFromKafka();
   }
 
-  public void populateTopicMetrics(Map<String, KafkaTopicDescription> topicDescriptionMap) {
+  public void populateTopicMetrics(KafkaCluster cluster, Map<String, KafkaTopicDescription> topicDescriptionMap) {
     // Publish kafka topic metrics including topic size in byte, number of partitions and retention period in ms.
     for (KafkaTopicDescription topicDescription : topicDescriptionMap.values()) {
       Map<String, String> metricsTags = new HashMap<String, String>() {{
         put("topicName", topicDescription.getName());
         put("isInternal", String.valueOf(topicDescription.isInternal()));
+        put("clusterName", cluster.getName());
+        put("clusterId", cluster.getClusterId());
       }};
       // Topic size
       double topicSize = getTopicSizeByteFromTopicDescription(topicDescription);

--- a/orion-server/src/main/java/com/pinterest/orion/server/OrionServer.java
+++ b/orion-server/src/main/java/com/pinterest/orion/server/OrionServer.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 
 import javax.servlet.FilterRegistration;
 
+import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricName;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -300,22 +301,41 @@ public class OrionServer extends Application<OrionConf> {
     new OrionServer().run(args);
   }
 
-  public static void metricsCounterInc(String subject, String action, String outcome, Map<String, String> tagMap) {
-    /*
-    Static helper class doing counter.inc() for Orion Server metrics.
-    It takes 3 string to form the metrics path.
-     */
+  private static MetricName constructMetricsName(String subject, String action, String outcome, Map<String, String> tagMap) {
     if (tagMap == null) {
       tagMap = new HashMap<>(); // MetricName needs to be initialized with non-null value.
     }
+    return new MetricName(
+            String.format("orion.%s.%s.%s", subject, action, outcome),
+            tagMap
+    );
+  }
+
+  public static void metricsCounterInc(String subject, String action, String outcome, Map<String, String> tagMap) {
+    /*
+    Static helper class doing counter.inc() for Orion Server metrics.
+    It takes 3 Strings to form the metrics path.
+     */
     try {
-      MetricName metricName = new MetricName(
-              String.format("orion.%s.%s.%s", subject, action, outcome),
-              tagMap
-      );
-      METRICS.counter(metricName).inc();
+      METRICS.counter(constructMetricsName(subject, action, outcome, tagMap)).inc();
     } catch (Exception e) {
       logger.log(Level.WARNING, "ActionEngine failed to run tsdb metrics counter.inc(). Error: ", e);
+    }
+  }
+
+  public static void metricsGaugeNum(String subject, String action, String outcome, Map<String, String> tagMap,
+                                     double value) {
+    /*
+    Static helper class doing metrics.gauge for Orion Server metrics.
+    It takes 3 Strings to form the metrics path and a double value as the metrics value.
+     */
+    try {
+      METRICS.gauge(
+              constructMetricsName(subject, action, outcome, tagMap),
+              () -> (Gauge<Double>) () -> value
+      );
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "ActionEngine failed to run tsdb metrics gauge. Error: ", e);
     }
   }
 }


### PR DESCRIPTION
Publish kafka topic metrics including topic size in byte, number of partitions and retention period in ms
* In KafkaTopicSensor, add a new function called populateTopicMetrics to publishing those metrics.
* In OrionServer, add a new helper called metricsGaugeNum for publishing numeric values. 
* Slightly refactor the logic of making MetricName and MetricsTag. 