### PR TITLE
Change metrics unit (byte->mb, ms->minute); Remove redundant prefix; Attempt to fix missing metrics

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/server/OrionServer.java
+++ b/orion-server/src/main/java/com/pinterest/orion/server/OrionServer.java
@@ -306,7 +306,7 @@ public class OrionServer extends Application<OrionConf> {
       tagMap = new HashMap<>(); // MetricName needs to be initialized with non-null value.
     }
     return new MetricName(
-            String.format("orion.%s.%s.%s", subject, action, outcome),
+            String.format("%s.%s.%s", subject, action, outcome), // orion.server prefix will be added automatically.
             tagMap
     );
   }


### PR DESCRIPTION
Change metrics unit (byte->mb, ms->minute)
byte and ms are too small. We don't need that level of granularity. Change to megabyte and minute. 

Remove redundant prefix
Now metrics name looks like orion.server.orion.kafkaTopic.size.byte. Remove the duplicated orion. 

Attempt to fix missing metrics: Topic size metrics do not present correctly. I directly copied the code from https://github.com/pinterest/orion/blob/master/orion-server/src/main/java/com/pinterest/orion/core/kafka/KafkaCluster.java#L311 Hope this logic can work. 