### PR TITLE
Add a null check in MemQ getTopicPartitionsForNode; Revert metricsCounterInc change

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/RebootEC2InstanceAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/RebootEC2InstanceAction.java
@@ -97,8 +97,8 @@ public class RebootEC2InstanceAction extends NodeAction {
           getEngine().alert(AlertLevel.HIGH,
               new AlertMessage("Replacement error on " + hostname,
                   "Post reboot of " + hostname + " health check timed out", getOwner(), hostname));
-          OrionServer.metricsGaugeNum(
-                  "broker.reboot.healthcheck.timeout", 1,
+          OrionServer.metricsCounterInc(
+                  "broker.reboot.healthcheck.timeout",
                   new HashMap<String, String>() {{
                     put("hostname", hostname);
                     put("instanceId", instanceId);

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/ReplaceEC2InstanceAction.java
@@ -152,8 +152,8 @@ public class ReplaceEC2InstanceAction extends NodeAction {
           );
           getEngine().alert(AlertLevel.MEDIUM, msg);
           getEngine().alert(AlertLevel.HIGH, msg);
-          OrionServer.metricsGaugeNum(
-                  "broker.replacement.state.missing", 1,
+          OrionServer.metricsCounterInc(
+                  "broker.replacement.state.missing",
                   new HashMap<String, String>() {{
                     put("hostname", hostname);
                     put("instanceId", instanceId);
@@ -210,8 +210,8 @@ public class ReplaceEC2InstanceAction extends NodeAction {
         getEngine().alert(AlertLevel.HIGH,
             new AlertMessage("Replacement error on " + hostname,
                 "Post replacement of " + hostname + " health check timed out", getOwner(), hostname));
-        OrionServer.metricsGaugeNum(
-                "broker.replacement.healthcheck.timeout", 1,
+        OrionServer.metricsCounterInc(
+                "broker.replacement.healthcheck.timeout",
                 new HashMap<String, String>() {{
                   put("hostname", hostname);
                   put("instanceId", instanceId);

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/TerminateEC2InstanceAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/TerminateEC2InstanceAction.java
@@ -75,8 +75,8 @@ public class TerminateEC2InstanceAction extends NodeAction {
         );
         getEngine().alert(AlertLevel.MEDIUM, msg);
         getEngine().alert(AlertLevel.HIGH, msg);
-        OrionServer.metricsGaugeNum(
-                "broker.waitingtermination.getstate.error", 1,
+        OrionServer.metricsCounterInc(
+                "broker.waitingtermination.getstate.error",
                 new HashMap<String, String>() {{
                   put("hostname", hostname);
                   put("instanceId", instanceId);

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/MinIsrRfConflictResolutionAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/MinIsrRfConflictResolutionAction.java
@@ -67,8 +67,8 @@ public class MinIsrRfConflictResolutionAction extends AbstractKafkaAction {
                     topicName + " on cluster " + getEngine().getCluster().getClusterId();
             AlertMessage alertMessage = new AlertMessage(title, message, "orion");
             getEngine().alert(AlertLevel.HIGH, alertMessage);
-            OrionServer.metricsGaugeNum(
-                    "replicationfactor.minisr.conflict", 1,
+            OrionServer.metricsCounterInc(
+                    "replicationfactor.minisr.conflict",
                     new HashMap<String, String>() {{
                         put("cluster", getEngine().getCluster().getClusterId());
                         put("topic", topicName);

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokerHealingOperator.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokerHealingOperator.java
@@ -161,8 +161,8 @@ public class BrokerHealingOperator extends KafkaOperator {
           "Orion agents on " + cluster.getClusterId() + " are unhealthy, no URPs on the cluster: " + alertableUnhealthyAgentBrokersWithoutURPs,
           "orion"
       ));
-      OrionServer.metricsGaugeNum(
-              "broker.agent.unhealthy", 1,
+      OrionServer.metricsCounterInc(
+              "broker.agent.unhealthy",
               new HashMap<String, String>() {{
                 put("clusterId", cluster.getClusterId());
               }}
@@ -188,8 +188,8 @@ public class BrokerHealingOperator extends KafkaOperator {
           "Kafka service on " + cluster.getClusterId() + " are unhealthy, no URPs on the cluster: " + alertableUnhealthyBrokersWithoutURPs,
           "orion"
       ));
-      OrionServer.metricsGaugeNum(
-              "broker.service.unhealthy", 1,
+      OrionServer.metricsCounterInc(
+              "broker.service.unhealthy",
               new HashMap<String, String>() {{
                 put("clusterId", cluster.getClusterId());
               }}
@@ -239,8 +239,8 @@ public class BrokerHealingOperator extends KafkaOperator {
           "Brokers " + candidates + " are unhealthy",
           "orion"
       ));
-      OrionServer.metricsGaugeNum(
-              "broker.services.unhealthy", 1,
+      OrionServer.metricsCounterInc(
+              "broker.services.unhealthy",
               new HashMap<String, String>() {{
                 put("clusterId", cluster.getClusterId());
               }}

--- a/orion-server/src/main/java/com/pinterest/orion/core/memq/MemqBroker.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/memq/MemqBroker.java
@@ -15,8 +15,8 @@
  *******************************************************************************/
 package com.pinterest.orion.core.memq;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 
@@ -43,9 +43,10 @@ public class MemqBroker extends Node {
       Attribute attribute = cluster.getAttribute(MemqClusterSensor.RAW_BROKER_INFO);
       Map<String, Broker> rawBrokerMap = attribute.getValue();
       Broker broker = rawBrokerMap.get(currentNodeInfo.getNodeId());
-      return broker.getAssignedTopics();
-    } else {
-      return Arrays.asList();
+      if (broker != null) {
+        return broker.getAssignedTopics();
+      }
     }
+    return new HashSet<>();
   }
 }


### PR DESCRIPTION
* Add a null check in MemQ getTopicPartitionsForNode
  * If the broker was removed, getTopicPartitionsForNode method of that node can still be called because the currentNodeInfo is in ClusterManager nodeMap. However, the nodeId is not rawBrokerMap in next ClusterSensor refresh. This can cause exception and make UI crush.
  * getAssignedTopics is returning a Set<TopicConfig>. I let the empty return to be a Set<> to make them consistent. 
* Revert metricsCounterInc change