### PR TITLE
Hide memq broker if broker is no longer in ZK

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/Node.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/Node.java
@@ -216,4 +216,8 @@ public abstract class Node implements Serializable {
   public void setMaintenance(boolean maintenance) {
     this.maintenance = maintenance;
   }
+
+  public boolean isDecommissioned() {
+    return getNodeStatus().equals(NodeStatus.DECOMMISSIONED);
+  }
 }

--- a/orion-server/src/main/java/com/pinterest/orion/core/memq/MemqBroker.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/memq/MemqBroker.java
@@ -44,7 +44,10 @@ public class MemqBroker extends Node {
       Map<String, Broker> rawBrokerMap = attribute.getValue();
       Broker broker = rawBrokerMap.get(currentNodeInfo.getNodeId());
       if (broker != null) {
+        setNodeStatus(NodeStatus.COMMISSIONED);
         return broker.getAssignedTopics();
+      } else {
+        setNodeStatus(NodeStatus.DECOMMISSIONED);
       }
     }
     return new HashSet<>();

--- a/orion-server/src/main/resources/webapp/src/basic-components/Nodes.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/Nodes.js
@@ -170,6 +170,11 @@ function Nodes({ cluster, isAdmin }) {
   if (cluster.nodeMap) {
     rows = Object.values(cluster.nodeMap);
   }
+  for(let i=0; i<rows.length; i++) {
+    if (rows[i].decommissioned) {
+      rows.splice(i, 1)
+    }
+  }
   let ClusterNodeDetails = loadClusterNodeType(cluster);
 
   const data = rows.map((row) => dataFunction(row));


### PR DESCRIPTION
Check node status tag. If the tag is DECOMMISSIONED, the node will no longer be shown in UX.

DECOMMISSIONED tag is not used at other places. Kafka node wont be impacted and can also benefit from this feature. 