### PR TITLE
Show broker name in memq topic page

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqClusterSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqClusterSensor.java
@@ -86,12 +86,12 @@ public class MemqClusterSensor extends MemqSensor {
         rawBrokerMap.put(broker.getBrokerIP(), broker);
         for (TopicConfig topicConfig : broker.getAssignedTopics()) {
           String topic = topicConfig.getTopic();
-          List<String> brokerIds = writeBrokerAssignments.get(topic);
-          if (brokerIds == null) {
-            brokerIds = new ArrayList<>();
-            writeBrokerAssignments.put(topic, brokerIds);
+          List<String> hostnames = writeBrokerAssignments.get(topic);
+          if (hostnames == null) {
+            hostnames = new ArrayList<>();
+            writeBrokerAssignments.put(topic, hostnames);
           }
-          brokerIds.add(broker.getBrokerIP());
+          hostnames.add(hostname);
         }
       }
 

--- a/orion-server/src/main/resources/webapp/src/basic-components/MemQ/MemqTopic.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/MemQ/MemqTopic.js
@@ -173,7 +173,7 @@ function getTopicWritePartitionsData(rowData) {
     rows.map((partition) => {
       data.push({
         partition: id++,
-        broker: partition,
+        brokerName: partition.split(".", 1)[0],
       });
     });
   }
@@ -183,7 +183,7 @@ function getTopicWritePartitionsData(rowData) {
 function getTopicWritePartitionsColumns() {
   return [
     { title: "Partition", field: "partition" },
-    { title: "Broker", field: "broker" },
+    { title: "Broker Name", field: "brokerName" },
   ];
 }
 


### PR DESCRIPTION
Show broker name in memq topic page. Now it's showing the broker ip address.

ClusterSensor is recording a string array and sends it to MemqTopic.js for renderning. I just make it record host name strings instead of ip strings. I dont plan to change it to map array to render more things now.   