### PR TITLE
Implement ClusterRecoveryAction

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/generic/ServiceStabilityCheckAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/generic/ServiceStabilityCheckAction.java
@@ -49,8 +49,8 @@ public class ServiceStabilityCheckAction extends NodeAction {
       }
 
       getResult().appendOut(
-          "Node is currently stable after " + (time - now) + " seconds. Still waiting for " + (
-              duration - (time - now)) + " seconds.");
+          "Node is currently stable after " + (time - now) + " ms. Still waiting for " + (
+              duration - (time - now)) + " ms.");
       Thread.sleep(30_000); // might want to make it configurable
     }
     markSucceeded();

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/BrokerRecoveryAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/BrokerRecoveryAction.java
@@ -46,7 +46,7 @@ public class BrokerRecoveryAction extends NodeAction {
   public static final String ATTR_NONEXISTENT_HOST_KEY = "nonexistent_host";
   public static final String CONF_DRY_RUN_REPLACEMENT_KEY = "dry_run";
   public static final String CONF_OVERRIDE_IMAGE_KEY = "override_image";
-  private boolean isDryRun = false;
+  private boolean isDryRun = false;  // Enable dryrun to prevent EC2 actions being triggered. Useful for testing.
   private String amiOverride = null;
 
   @Override
@@ -209,14 +209,14 @@ public class BrokerRecoveryAction extends NodeAction {
   @Override
   public String getName() {
     // Different action names are required for BrokerRecoveryAction to be dispatched from same ClusterRecoveryAction.
-    String nodeId = "Unknown Node";
+    String name = "BrokerRecoveryAction - " + this.getUuid().toString(); // default to action uuid if nodeId is not set.
     if (containsAttribute(OrionConstants.NODE_ID)) {
-      nodeId = getAttribute(OrionConstants.NODE_ID).getValue();
+      name = String.format(
+              "BrokerRecoveryAction for broker %s",
+              getAttribute(OrionConstants.NODE_ID).getValue().toString());
     }
-    return String.format(
-            "BrokerRecoveryAction for %s %s",
-           nodeId,
-            (isDryRun ? " - Dry Run" : ""));
+    name = name + (isDryRun ? " - Dry Run" : "");
+    return name;
   }
 
   private boolean isHostReachable(String hostname, int port) {

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/BrokerRecoveryAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/BrokerRecoveryAction.java
@@ -41,7 +41,6 @@ public class BrokerRecoveryAction extends NodeAction {
   private static final int maxRetries = 3;
   private static final int retryIntervalMilliseconds = 1000;
 
-  public static final String ATTR_LAST_REPLACED_NODE_ID_KEY = "last_replaced_node_id";
   public static final String ATTR_TRY_TO_RESTART_KEY = "try_restart";
   public static final String ATTR_NODE_EXISTS_KEY = "node_exists";
   public static final String ATTR_NONEXISTENT_HOST_KEY = "nonexistent_host";
@@ -65,6 +64,9 @@ public class BrokerRecoveryAction extends NodeAction {
   public void runAction() {
     boolean nodeExists = true;
     String nodeId = getAttribute(OrionConstants.NODE_ID).getValue();
+    String startNote = "BrokerRecoveryAction for " + nodeId + " started.";
+    logger.info(startNote);
+    getResult().appendOut(startNote);
     if(containsAttribute(ATTR_NODE_EXISTS_KEY)) {
       nodeExists = getAttribute(ATTR_NODE_EXISTS_KEY).getValue();
     }
@@ -133,7 +135,6 @@ public class BrokerRecoveryAction extends NodeAction {
           return;
         }
       }
-      getEngine().getCluster().setAttribute(ATTR_LAST_REPLACED_NODE_ID_KEY, nodeId);
       OrionServer.METRICS.counter(metricPrefix.resolve("replace_success")).inc();
       markSucceeded();
     } catch (Exception e) {
@@ -207,7 +208,15 @@ public class BrokerRecoveryAction extends NodeAction {
 
   @Override
   public String getName() {
-    return "Broker Recovery" + (isDryRun ? " - Dry Run" : "");
+    // Different action names are required for BrokerRecoveryAction to be dispatched from same ClusterRecoveryAction.
+    String nodeId = "Unknown Node";
+    if (containsAttribute(OrionConstants.NODE_ID)) {
+      nodeId = getAttribute(OrionConstants.NODE_ID).getValue();
+    }
+    return String.format(
+            "BrokerRecoveryAction for %s %s",
+           nodeId,
+            (isDryRun ? " - Dry Run" : ""));
   }
 
   private boolean isHostReachable(String hostname, int port) {

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ClusterRecoveryAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ClusterRecoveryAction.java
@@ -1,0 +1,223 @@
+package com.pinterest.orion.core.actions.kafka;
+
+import com.google.common.collect.Sets;
+import com.pinterest.orion.core.Attribute;
+import com.pinterest.orion.core.Cluster;
+import com.pinterest.orion.core.Node;
+import com.pinterest.orion.core.actions.Action;
+import com.pinterest.orion.core.actions.alert.AlertLevel;
+import com.pinterest.orion.core.actions.alert.AlertMessage;
+import com.pinterest.orion.core.actions.generic.GenericClusterWideAction;
+import com.pinterest.orion.server.OrionServer;
+import com.pinterest.orion.utils.OrionConstants;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+public class ClusterRecoveryAction extends GenericClusterWideAction.ClusterAction {
+
+    protected Cluster cluster;
+    protected Set<String> candidates;
+    protected Set<String> deadBrokers;
+    protected Set<String> maybeDeadBrokers;
+    protected Set<String> nonExistentBrokers;
+    protected Set<String> sensorSet;
+    private static final Logger logger = Logger.getLogger(ClusterRecoveryAction.class.getName());
+    public static final String ATTR_RECOVERING_NODES = "recovering_nodes";
+    private static final long cooldownMilliseconds = 3600_000L; // 1 hour
+
+    @Override
+    public String getName() {
+        return "Cluster Recovery Action";
+    }
+
+    @Override
+    public void runAction() throws Exception {
+        String startNote = String.format(
+                "ClusterRecoveryAction will try to recover brokers %s in cluster %s. ",
+                candidates,
+                cluster.getClusterId());
+        logger.info(startNote);
+        getResult().appendOut(startNote);
+        try {
+            boolean isSucceed = healBrokers(candidates);
+            if (isSucceed) {
+                markSucceeded();
+            } else {
+                markFailed(String.format(
+                        "ClusterRecoveryAction failed to recover brokers %s in cluster %s. ",
+                        candidates,
+                        cluster.getClusterId()));
+            }
+        } catch (Exception e) {
+            markFailed(e);
+        }
+    }
+
+    protected void healBroker(String deadBrokerId) throws Exception {
+        // This will trigger an action that will attempt to replace the broker.
+        // If agent is still online but Kafka process is down, it will try to restart the broker first.
+        Action brokerRecoveryAction = newBrokerRecoveryAction();
+        brokerRecoveryAction.setAttribute(OrionConstants.NODE_ID, deadBrokerId, sensorSet);
+        brokerRecoveryAction.setOwner("ClusterRecoveryAction");
+
+        if (nonExistentBrokers.contains(deadBrokerId)) {
+            Node existingNode = cluster.getNodeMap().values().iterator().next();
+            String extractedName = deriveNonexistentHostname(
+                    existingNode.getCurrentNodeInfo().getHostname(),
+                    existingNode.getCurrentNodeInfo().getNodeId(),
+                    deadBrokerId
+            );
+            // setting these attributes to indicate that the node doesn't exist in cluster map, and should skip any node-related checks
+            brokerRecoveryAction.setAttribute(BrokerRecoveryAction.ATTR_NODE_EXISTS_KEY, false);
+            brokerRecoveryAction.setAttribute(BrokerRecoveryAction.ATTR_NONEXISTENT_HOST_KEY, extractedName);
+        }
+        if (maybeDeadBrokers.contains(deadBrokerId)) {
+            // Setting this flag in the action will restart the broker before replacing the broker
+            brokerRecoveryAction.setAttribute(BrokerRecoveryAction.ATTR_TRY_TO_RESTART_KEY, true);
+            String restartNote = "Will try to restart node " + deadBrokerId + " before replacing it. ";
+            logger.info(restartNote);
+            getResult().appendOut(restartNote);
+        }
+        String dispatchNote = String.format(
+                "Dispatching BrokerRecoveryAction for node %s in cluster %s. ",
+                deadBrokerId,
+                cluster.getClusterId());
+        logger.info(dispatchNote);
+        getResult().appendOut(dispatchNote);
+        getEngine().dispatch(brokerRecoveryAction);
+    }
+
+    protected boolean healBrokers(Set<String> candidates) throws Exception {
+        String output;
+        boolean isSucceed = false;
+        if (candidates.size() == 1) {
+            output = String.format(
+                    "ClusterRecoveryAction trys to recover broker %s. ",
+                    candidates.iterator().next());
+            String deadBrokerId = candidates.iterator().next();
+            healBroker(deadBrokerId);
+            logger.info(output);
+            isSucceed = true;
+        } else if (candidates.size() > 1){
+            // more than 1 brokers are dead... better alert and have human intervention
+            output = String.format("More than one brokers are in bad state - dead: %s, service down: %s. " +
+                            "ClusterRecoveryAction skips automatic recovery and pages oncall. ",
+                    deadBrokers, maybeDeadBrokers);
+            cluster.getActionEngine().alert(AlertLevel.HIGH, new AlertMessage(
+                    candidates.size() + " brokers on " + cluster.getClusterId() + " are unhealthy",
+                    output,
+                    "orion"
+            ));
+            OrionServer.metricsCounterInc(
+                    "broker.services.unhealthy",
+                    new HashMap<String, String>() {{
+                        put("clusterId", cluster.getClusterId());
+                    }}
+            );
+            logger.severe(output);
+        } else {
+            output = String.format("No candidates for healing in cluster %s. ", cluster.getClusterId());
+            logger.warning(output);
+        }
+        getResult().appendOut(output);
+        return isSucceed;
+    }
+
+    public void setCandidates(Set<String> candidates) {
+        this.candidates = candidates;
+    }
+
+    public void setDeadBrokers(Set<String> deadBrokers) {
+        this.deadBrokers = deadBrokers;
+    }
+
+    public void setMaybeDeadBrokers(Set<String> maybeDeadBrokers) {
+        this.maybeDeadBrokers = maybeDeadBrokers;
+    }
+
+    public void setNonExistentBrokers(Set<String> nonExistentBrokers) {
+        this.nonExistentBrokers = nonExistentBrokers;
+    }
+
+    public void setCluster(Cluster cluster) {
+        this.cluster = cluster;
+    }
+
+    public void setSensorSet(Set<String> sensorSet) {
+        this.sensorSet = sensorSet;
+    }
+
+    protected static String deriveNonexistentHostname(String existingHostname, String existingId, String nonExistingId) {
+        existingHostname = existingHostname.split("\\.", 2)[0]; // sanitize potential suffixes
+        int diff = nonExistingId.length() - existingId.length();
+        if ( diff > 0 ) {
+            existingId = StringUtils.leftPad(existingId, diff, '0');
+        } else if (diff < 0) {
+            nonExistingId = StringUtils.leftPad(nonExistingId, -diff, '0');
+        }
+
+        String ret = existingHostname.replace(existingId, nonExistingId);
+        if (ret.equals(existingHostname)) {
+            return null;
+        }
+        return ret;
+    }
+
+    protected BrokerRecoveryAction newBrokerRecoveryAction() {
+        return new BrokerRecoveryAction();
+    }
+
+    public static void removeRecoveringNodesFromCandidates(Set<String> candidates, Cluster cluster) {
+        // Remove all the nodes that are replaced within cooldownMilliseconds from candidates.
+        if (candidates == null || candidates.isEmpty()) {
+            return;
+        }
+        Attribute recoveringNodesAttr = cluster.getAttribute(ATTR_RECOVERING_NODES);
+        if (recoveringNodesAttr == null || recoveringNodesAttr.getValue() == null) {
+            // Initialize the recovering node set with the new set of candidates.
+            cluster.setAttribute(ATTR_RECOVERING_NODES, candidates);
+            return;
+        }
+        Set<String> recoveringNodes = recoveringNodesAttr.getValue();
+        if (System.currentTimeMillis() - recoveringNodesAttr.getUpdateTimestamp() < cooldownMilliseconds) {
+            // Remove all the nodes that are replaced within cooldownMilliseconds from candidates
+            for (String node : recoveringNodes) {
+                if (candidates.contains(node)) {
+                    candidates.remove(node);
+                }
+            }
+            if (candidates.isEmpty()) {
+                // All the candidates are replaced within cooldownMilliseconds. Skip this round.
+                logger.warning(String.format(
+                        "Nodes in cooldown phase: %s; Last action time: %s; Skip recovering",
+                        recoveringNodes,
+                        new Date(recoveringNodesAttr.getUpdateTimestamp())));
+            } else {
+                // Add the new set of recovering nodes to the recovering node set. Reset update time.
+                logger.warning(String.format(
+                        "Nodes in cooldown phase: %s; Last action time: %s; Recovering nodes: %s",
+                        recoveringNodes,
+                        new Date(recoveringNodesAttr.getUpdateTimestamp()),
+                        candidates));
+                // TODO: Can add alert here if the size of recoveringNodes is too large.
+                cluster.setAttribute(ATTR_RECOVERING_NODES, new HashSet<>(Sets.union(recoveringNodes, candidates)));
+            }
+        } else {
+            // RecoveringNodes set reaches TTL. Replace the recovering node set with candidates.
+            logger.warning(String.format(
+                    "Previous recovering node set is timeout: " +
+                            "Nodes no longer in recovering mode: %s; " +
+                            "Last action time: %s; " +
+                            "Recovering nodes: %s",
+                    recoveringNodes,
+                    new Date(recoveringNodesAttr.getUpdateTimestamp()),
+                    candidates));
+            cluster.setAttribute(ATTR_RECOVERING_NODES, new HashSet<>(candidates));
+        }
+    }
+}

--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ClusterRecoveryAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/ClusterRecoveryAction.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -44,8 +45,7 @@ public class ClusterRecoveryAction extends GenericClusterWideAction.ClusterActio
         logger.info(startNote);
         getResult().appendOut(startNote);
         try {
-            boolean isSucceed = healBrokers(candidates);
-            if (isSucceed) {
+            if (healBrokers(candidates) && isChildActionsSuccess()) {
                 markSucceeded();
             } else {
                 markFailed(String.format(
@@ -58,51 +58,105 @@ public class ClusterRecoveryAction extends GenericClusterWideAction.ClusterActio
         }
     }
 
-    protected void healBroker(String deadBrokerId) throws Exception {
-        // This will trigger an action that will attempt to replace the broker.
-        // If agent is still online but Kafka process is down, it will try to restart the broker first.
+    /**
+     * Check if all the child actions finished.
+     * If any of the child actions failed, mark this action as failed.
+     * @return true if all the child actions are successful.
+     */
+    private boolean isChildActionsSuccess() {
+        boolean isSuccess = true;
+        List<Action> childActions = getChildren();
+        if (childActions == null || childActions.isEmpty()) {
+            return true;
+        }
+        for (Action childAction : childActions) {
+            try {
+                childAction.get(); // wait for the child action to finish
+            } catch (Exception e) {
+                String errorMsg = String.format(
+                        "Child action %s failed: %s",
+                        childAction.getName(),
+                        e.getMessage());
+                logger.warning(errorMsg);
+                getResult().appendOut(errorMsg);
+                isSuccess = false;
+            }
+            isSuccess = isSuccess && childAction.isSuccess();
+        }
+        return isSuccess;
+    }
+
+    /**
+     * This method triggers a BrokerRecoveryAction for a broker.
+     * If the broker is non-existent or dead, it will replace the broker with a new broker.
+     * If the broker is still online but Kafka process is down, it will try to restart the broker first. If restart fails, it will replace the broker.
+     * @param brokerId the id of the broker to be recovered.
+     * @throws Exception if the child action is not triggered successfully.
+     */
+    protected void triggerBrokerRecoveryAction(String brokerId) throws Exception {
+
         Action brokerRecoveryAction = newBrokerRecoveryAction();
-        brokerRecoveryAction.setAttribute(OrionConstants.NODE_ID, deadBrokerId, sensorSet);
+        brokerRecoveryAction.setAttribute(OrionConstants.NODE_ID, brokerId, sensorSet);
         brokerRecoveryAction.setOwner("ClusterRecoveryAction");
 
-        if (nonExistentBrokers.contains(deadBrokerId)) {
+        if (nonExistentBrokers.contains(brokerId)) {
             Node existingNode = cluster.getNodeMap().values().iterator().next();
             String extractedName = deriveNonexistentHostname(
                     existingNode.getCurrentNodeInfo().getHostname(),
                     existingNode.getCurrentNodeInfo().getNodeId(),
-                    deadBrokerId
+                    brokerId
             );
             // setting these attributes to indicate that the node doesn't exist in cluster map, and should skip any node-related checks
             brokerRecoveryAction.setAttribute(BrokerRecoveryAction.ATTR_NODE_EXISTS_KEY, false);
             brokerRecoveryAction.setAttribute(BrokerRecoveryAction.ATTR_NONEXISTENT_HOST_KEY, extractedName);
         }
-        if (maybeDeadBrokers.contains(deadBrokerId)) {
+        if (maybeDeadBrokers.contains(brokerId)) {
             // Setting this flag in the action will restart the broker before replacing the broker
             brokerRecoveryAction.setAttribute(BrokerRecoveryAction.ATTR_TRY_TO_RESTART_KEY, true);
-            String restartNote = "Will try to restart node " + deadBrokerId + " before replacing it. ";
+            String restartNote =
+                    "BrokerRecoveryAction will try to restart node " + brokerId + " before replacing it.";
             logger.info(restartNote);
             getResult().appendOut(restartNote);
         }
-        String dispatchNote = String.format(
-                "Dispatching BrokerRecoveryAction for node %s in cluster %s. ",
-                deadBrokerId,
+        String note = String.format(
+                "Trigger BrokerRecoveryAction for node %s in cluster %s. Check the child action for details.",
+                brokerId,
                 cluster.getClusterId());
-        logger.info(dispatchNote);
-        getResult().appendOut(dispatchNote);
-        getEngine().dispatch(brokerRecoveryAction);
+        logger.info(note);
+        getResult().appendOut(note);
+        dispatchChildAction(brokerRecoveryAction);
     }
 
+    /**
+     * This method adds a child action to the action list.
+     * It also dispatches the child action to the action engine.
+     * @param childAction the child action to be added.
+     * @throws Exception if the child action is not triggered successfully.
+     */
+    private void dispatchChildAction(Action childAction) throws Exception {
+        this.getChildren().add(childAction);
+        getEngine().dispatchChild(this, childAction);
+    }
+
+    /**
+     * This method triggers a BrokerRecoveryAction for each broker in candidates.
+     * It checks if the number of candidates is more than one.
+     * If the number of candidates is more than one, it will alert and not trigger any action.
+     * @param candidates a set of broker ids that are in bad states.
+     * @return true if all the child actions are triggered successfully.
+     * @throws Exception if any of the child actions is not triggered successfully.
+     */
     protected boolean healBrokers(Set<String> candidates) throws Exception {
         String output;
-        boolean isSucceed = false;
+        boolean isActionTriggered = false;
         if (candidates.size() == 1) {
             output = String.format(
-                    "ClusterRecoveryAction trys to recover broker %s. ",
+                    "ClusterRecoveryAction attempts to recover broker %s. ",
                     candidates.iterator().next());
-            String deadBrokerId = candidates.iterator().next();
-            healBroker(deadBrokerId);
+            String brokerId = candidates.iterator().next();
             logger.info(output);
-            isSucceed = true;
+            triggerBrokerRecoveryAction(brokerId);
+            isActionTriggered = true;
         } else if (candidates.size() > 1){
             // more than 1 brokers are dead... better alert and have human intervention
             output = String.format("More than one brokers are in bad state - dead: %s, service down: %s. " +
@@ -125,7 +179,7 @@ public class ClusterRecoveryAction extends GenericClusterWideAction.ClusterActio
             logger.warning(output);
         }
         getResult().appendOut(output);
-        return isSucceed;
+        return isActionTriggered;
     }
 
     public void setCandidates(Set<String> candidates) {
@@ -152,6 +206,13 @@ public class ClusterRecoveryAction extends GenericClusterWideAction.ClusterActio
         this.sensorSet = sensorSet;
     }
 
+    /**
+     * This method derives the hostname of a non-existent node from the hostname of an existing node.
+     * @param existingHostname the hostname of an existing node.
+     * @param existingId the id of the existing node.
+     * @param nonExistingId the id of the non-existent node.
+     * @return the hostname of the non-existent node.
+     */
     protected static String deriveNonexistentHostname(String existingHostname, String existingId, String nonExistingId) {
         existingHostname = existingHostname.split("\\.", 2)[0]; // sanitize potential suffixes
         int diff = nonExistingId.length() - existingId.length();
@@ -172,6 +233,13 @@ public class ClusterRecoveryAction extends GenericClusterWideAction.ClusterActio
         return new BrokerRecoveryAction();
     }
 
+    /**
+     * This method removes all the nodes that are replaced within cooldownMilliseconds from candidates.
+     * It also adds the new set of recovering nodes to the recovering node set.
+     * If the recovering node set reaches TTL, it replaces the recovering node set with candidates.
+     * @param candidates a set of nodes that are in bad states.
+     * @param cluster the cluster that the nodes belong to.
+     */
     public static void removeRecoveringNodesFromCandidates(Set<String> candidates, Cluster cluster) {
         // Remove all the nodes that are replaced within cooldownMilliseconds from candidates.
         if (candidates == null || candidates.isEmpty()) {

--- a/orion-server/src/test/java/com/pinterest/orion/core/actions/kafka/TestClusterRecoveryAction.java
+++ b/orion-server/src/test/java/com/pinterest/orion/core/actions/kafka/TestClusterRecoveryAction.java
@@ -1,0 +1,105 @@
+package com.pinterest.orion.core.actions.kafka;
+
+import com.google.common.collect.Sets;
+import com.pinterest.orion.core.Attribute;
+import com.pinterest.orion.core.Cluster;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.pinterest.orion.core.actions.kafka.ClusterRecoveryAction.removeRecoveringNodesFromCandidates;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class TestClusterRecoveryAction {
+
+    @Test
+    public void testRemoveRecoveringNodesFromCandidatesClearCandidates() {
+        Set<String> testCandidates = new HashSet<String>() {{
+            add("1");
+            add("2");
+        }};
+        Cluster testCluster = Mockito.mock(Cluster.class);
+        Mockito.when(testCluster.getClusterId()).thenReturn("test_cluster");
+        Set<String> testRecoveringNodes = new HashSet<String>() {{
+            add("1");
+            add("2");
+        }};
+        Attribute testRecoveringNodesAttribute = Mockito.mock(Attribute.class);
+        Mockito.when(testRecoveringNodesAttribute.getValue()).thenReturn(testRecoveringNodes);
+        Mockito.when(testRecoveringNodesAttribute.getUpdateTimestamp()).thenReturn(System.currentTimeMillis());
+        Mockito.when(testCluster.getAttribute(ClusterRecoveryAction.ATTR_RECOVERING_NODES))
+                .thenReturn(testRecoveringNodesAttribute);
+        removeRecoveringNodesFromCandidates(testCandidates, testCluster);
+        // testCandidates should be cleared.
+        // testRecoveringNodes should not be updated.
+        assertEquals(testCandidates, new HashSet<String>());
+        verify(testCluster, never())
+                .setAttribute(Mockito.eq(ClusterRecoveryAction.ATTR_RECOVERING_NODES), Mockito.any());
+    }
+
+    @Test
+    public void testRemoveRecoveringNodesFromCandidatesRecoveringNodeTimeout() {
+        Set<String> testCandidates = new HashSet<String>() {{
+            add("1");
+            add("2");
+        }};
+        Cluster testCluster = Mockito.mock(Cluster.class);
+        Mockito.when(testCluster.getClusterId()).thenReturn("test_cluster");
+        Set<String> testRecoveringNodes = new HashSet<String>() {{
+            add("1");
+            add("3");
+        }};
+        Attribute testRecoveringNodesAttribute = Mockito.mock(Attribute.class);
+        Mockito.when(testRecoveringNodesAttribute.getValue()).thenReturn(testRecoveringNodes);
+        Mockito.when(testRecoveringNodesAttribute.getUpdateTimestamp()).thenReturn(0L);
+        Mockito.when(testCluster.getAttribute(ClusterRecoveryAction.ATTR_RECOVERING_NODES))
+                .thenReturn(testRecoveringNodesAttribute);
+        removeRecoveringNodesFromCandidates(testCandidates, testCluster);
+        // testCandidates should not be updated because testRecoveringNodes reaches TTL.
+        // testRecoveringNodes should be updated to testCandidates values.
+        assertEquals(testCandidates, new HashSet<String>() {{
+            add("1");
+            add("2");
+        }});
+        ArgumentCaptor<Set> argument = ArgumentCaptor.forClass(Set.class);
+        verify(testCluster, Mockito.times(1))
+                .setAttribute(Mockito.eq(ClusterRecoveryAction.ATTR_RECOVERING_NODES), argument.capture());
+        assertEquals(argument.getValue(), testCandidates);
+    }
+
+    @Test
+    public void testRemoveRecoveringNodesFromCandidatesUpdateRecoveringNodeAndCandidates() {
+        Set<String> testCandidates = new HashSet<String>() {{
+            add("1");
+            add("2");
+            add("3");
+        }};
+        Cluster testCluster = Mockito.mock(Cluster.class);
+        Mockito.when(testCluster.getClusterId()).thenReturn("test_cluster");
+        Set<String> testRecoveringNodes = new HashSet<String>() {{
+            add("2");
+            add("3");
+            add("4");
+        }};
+        Attribute testRecoveringNodesAttribute = Mockito.mock(Attribute.class);
+        Mockito.when(testRecoveringNodesAttribute.getValue()).thenReturn(testRecoveringNodes);
+        Mockito.when(testRecoveringNodesAttribute.getUpdateTimestamp()).thenReturn(System.currentTimeMillis());
+        Mockito.when(testCluster.getAttribute(ClusterRecoveryAction.ATTR_RECOVERING_NODES))
+                .thenReturn(testRecoveringNodesAttribute);
+        removeRecoveringNodesFromCandidates(testCandidates, testCluster);
+        // testCandidates should be updated to the difference between testCandidates and testRecoveringNodes.
+        // testRecoveringNodes should be updated to the union of testCandidates and testRecoveringNodes.
+        assertEquals(testCandidates, new HashSet<String>() {{
+            add("1");
+        }});
+        ArgumentCaptor<Set> argument = ArgumentCaptor.forClass(Set.class);
+        verify(testCluster, Mockito.times(1))
+                .setAttribute(Mockito.eq(ClusterRecoveryAction.ATTR_RECOVERING_NODES), argument.capture());
+        assertEquals(argument.getValue(), Sets.union(testCandidates, testRecoveringNodes));
+    }
+}


### PR DESCRIPTION
Implement ClusterRecoveryAction: Orion can automatically recover more than one brokers now. 

Broker issue can be detected by BrokerHealingOperator. Before this change, if one broker has outage, BrokerHealingOperator will trigger one BrokerRecoveryAction to recovery it. If more than one brokers have issues, BrokerHealingOperator just throws errors and does nothing.

This PR adds a layer ClusterRecoveryAction between BrokerHealingOperator and BrokerRecoveryAction. When BrokerHealingOperator detects one or more brokers with issues, it creates and dispatches a ClusterRecoveryAction to take care of it. ClusterRecoveryAction can decide whether to create multiple BrokerRecoveryActions to fix broker issues based on its own logic. 

To avoid one broker being fixed multiple time, the PR introduces a method called removeRecoveringNodesFromCandidates. This Set based lock can make sure in one big time frame, one broker only be healed once. 