### PR TITLE
Orion Broker Set UI Implementation 

### DIFF
--- a/orion-commons/src/main/java/com/pinterest/orion/common/NodeInfo.java
+++ b/orion-commons/src/main/java/com/pinterest/orion/common/NodeInfo.java
@@ -16,7 +16,9 @@
 package com.pinterest.orion.common;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class NodeInfo implements Serializable {
 
@@ -33,6 +35,32 @@ public class NodeInfo implements Serializable {
   private Map<String, String> serviceInfo;
   private Map<String, String> agentSettings;
   private Map<String, String> environment;
+  private Set<String> brokersets = new HashSet<>();
+  private Map<String, String> brokerStatus;
+  /**
+   * @param brokerStatus
+   */
+  public void setBrokerStatus(Map<String, String> brokerStatus) {
+    this.brokerStatus = brokerStatus;
+  }
+  /**
+   * @return the brokerStatus
+   */
+  public Map<String, String> getBrokerStatus() {
+    return brokerStatus;
+  }
+  /**
+   * @param brokersets
+   */
+  public void setBrokersets(Set<String> brokersets) {
+    this.brokersets = brokersets;
+  }
+  /**
+   * @return the brokersets
+   */
+  public Set<String> getBrokersets() {
+      return brokersets;
+  }
   /**
    * @return the timestamp
    */

--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/BrokersetStateSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/kafka/BrokersetStateSensor.java
@@ -1,0 +1,113 @@
+package com.pinterest.orion.core.automation.sensor.kafka;
+
+import com.pinterest.orion.core.Attribute;
+import com.pinterest.orion.core.Node;
+import com.pinterest.orion.core.kafka.Brokerset;
+import com.pinterest.orion.core.kafka.BrokersetState;
+import com.pinterest.orion.core.kafka.KafkaCluster;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+public class BrokersetStateSensor extends KafkaSensor {
+    private static final Logger logger = Logger.getLogger(BrokersetStateSensor.class.getName());
+    public static final String ATTR_BROKERSET_STATE_KEY = "brokersetState";
+
+    /**
+     * KafkaClusterInfoSensor loads the brokerset information from the config files.
+     * This sensor generates brokerset state information based on the brokerset information.
+     * @param cluster Kafka cluster to sense.
+     * @throws Exception If there is an error sensing the cluster.
+     */
+    @Override
+    public void sense(KafkaCluster cluster) throws Exception {
+        // Brokerset information and broker information are loaded from other sensors.
+        // If they are not ready, skip this sensor.
+        if (!cluster.containsAttribute(KafkaClusterInfoSensor.ATTR_BROKERSET_KEY)) {
+            // No brokerset information available. Skip.
+            return;
+        }
+        Attribute brokersetMapAttr = cluster.getAttribute(KafkaClusterInfoSensor.ATTR_BROKERSET_KEY);
+        if (brokersetMapAttr == null) {
+            // No brokerset information available. Skip.
+            return;
+        }
+        if (cluster.getNodeMap() == null || cluster.getNodeMap().isEmpty()) {
+            // No node information available. Skip.
+            return;
+        }
+        // Brokerset info from config files
+        Map<String, Brokerset> brokersetMap = brokersetMapAttr.getValue();
+        // Brokerset state map.
+        Map<String, BrokersetState> brokersetStateMap = new HashMap<>();
+        // BrokerId to brokerset alias set map
+        Map<String, Set<String>> brokerToBrokersetsMap = new HashMap<>();
+        for (String nodeId : cluster.getNodeMap().keySet()) {
+            brokerToBrokersetsMap.put(nodeId, new HashSet<>());
+        }
+        // Get broker ids for each brokerset.
+        for (Brokerset brokerset : brokersetMap.values()) {
+            String brokersetAlias = brokerset.getBrokersetAlias();
+            BrokersetState brokersetState = new BrokersetState(brokersetAlias);
+            Set<String> brokerIds = new HashSet<>();
+            List<Brokerset.BrokersetRange> brokersetRanges = brokerset.getEntries();
+            if (brokersetRanges == null || brokersetRanges.isEmpty()) {
+                logger.warning(String.format("Brokerset %s in cluster %s has no brokerset range.",
+                    brokersetAlias, cluster.getName()));
+                continue;
+            }
+            boolean invalidBrokerset = false;
+            for (Brokerset.BrokersetRange brokersetRange : brokersetRanges) {
+                int start = brokersetRange.getStartBrokerIdx();
+                int end = brokersetRange.getEndBrokerIdx();
+                for (int i = start; i <= end; i++) {
+                    String nodeId = Integer.toString(i);
+                    if (cluster.getNodeMap().containsKey(nodeId)) {
+                        Node node = cluster.getNodeMap().get(nodeId);
+                        brokerIds.add(node.getCurrentNodeInfo().getNodeId());
+                        brokerToBrokersetsMap.get(nodeId).add(brokersetAlias);
+                    } else {
+                        invalidBrokerset = true;
+                    }
+                }
+                brokersetState.addBrokerRange(Arrays.asList(start, end));
+            }
+            brokersetState.setBrokerIds(new ArrayList<>(brokerIds));
+            brokersetStateMap.put(brokersetAlias, brokersetState);
+            if (invalidBrokerset) {
+                handleInvalidBrokerset(brokersetAlias, cluster.getName());
+            }
+        }
+        // TODO: Add other brokerset status information (ex. usage data).
+        cluster.setAttribute(ATTR_BROKERSET_STATE_KEY, brokersetStateMap);
+        // Update node info with brokerset information.
+        for (Node node : cluster.getNodeMap().values()) {
+            if (node != null && node.getCurrentNodeInfo() != null) {
+                String nodeId = node.getCurrentNodeInfo().getNodeId();
+                node.getCurrentNodeInfo().setBrokersets(brokerToBrokersetsMap.get(nodeId));
+            }
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "BrokersetStateSensor";
+    }
+
+    /**
+     * Handle invalid brokerset.
+     * Invalid brokerset means that some brokers recorded in brokerset config files are not found in the cluster.
+     * @param brokersetAlias Brokerset alias.
+     * @param clusterId Cluster id.
+     */
+    protected void handleInvalidBrokerset(String brokersetAlias, String clusterId) {
+        logger.warning(String.format("Brokerset %s in cluster %s has invalid brokers.",
+            brokersetAlias, clusterId));
+    }
+}

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/BrokersetState.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/BrokersetState.java
@@ -1,0 +1,53 @@
+package com.pinterest.orion.core.kafka;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BrokersetState {
+    private String brokersetAlias;
+    private List<List<Integer>> brokersetRanges = new ArrayList<>();
+    private List<String> brokerIds;
+
+    public BrokersetState(String brokersetAlias) {
+        this.brokersetAlias = brokersetAlias;
+    }
+
+    public BrokersetState(String brokersetAlias, List<List<Integer>> brokersetRanges, List<String> brokerIds) {
+        this.brokersetAlias = brokersetAlias;
+        this.brokersetRanges = brokersetRanges;
+        this.brokerIds = brokerIds;
+    }
+
+    public int getSize() {
+        return brokerIds.size();
+    }
+
+    public String getBrokersetAlias() {
+        return brokersetAlias;
+    }
+
+    public void setBrokersetAlias(String brokersetAlias) {
+        this.brokersetAlias = brokersetAlias;
+    }
+
+    public List<List<Integer>> getBrokersetRanges() {
+        return brokersetRanges;
+    }
+
+    public void addBrokerRange(List<Integer> brokerRange) {
+        brokersetRanges.add(brokerRange);
+    }
+
+    public void setBrokersetRanges(List<List<Integer>> brokersetRanges) {
+        this.brokersetRanges = brokersetRanges;
+    }
+
+    public List<String> getBrokerIds() {
+        return brokerIds;
+    }
+
+    public void setBrokerIds(List<String> brokerIds) {
+        this.brokerIds = brokerIds;
+    }
+}

--- a/orion-server/src/main/java/com/pinterest/orion/core/kafka/BrokersetState.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/kafka/BrokersetState.java
@@ -5,48 +5,106 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BrokersetState {
+    /**
+     * The brokersetAlias is the alias of the brokerset.
+     */
     private String brokersetAlias;
+    /**
+     * The brokersetRanges are the ranges of brokerset that are in the brokerset.
+     * The brokersetRanges are obtained from the brokerset configuration file.
+     */
     private List<List<Integer>> brokersetRanges = new ArrayList<>();
-    private List<String> brokerIds;
-
+    /**
+     * The brokerIds are the ids of running broker that are in the brokerset.
+     * The brokerIds are obtained from the cluster state.
+     */
+    private List<String> brokerIds = new ArrayList<>();
+    /**
+     * The constructor of BrokersetState.
+     * @param brokersetAlias
+     */
     public BrokersetState(String brokersetAlias) {
         this.brokersetAlias = brokersetAlias;
     }
-
+    /**
+     * The constructor of BrokersetState.
+     * @param brokersetAlias
+     * @param brokersetRanges
+     * @param brokerIds
+     */
     public BrokersetState(String brokersetAlias, List<List<Integer>> brokersetRanges, List<String> brokerIds) {
         this.brokersetAlias = brokersetAlias;
         this.brokersetRanges = brokersetRanges;
         this.brokerIds = brokerIds;
     }
-
+    /**
+     * The method is used to get the size of brokerset.
+     * The size of brokerset is the number of brokers in the brokerset.
+     * It may not be equal to the sum of brokersetRanges if some brokers are not running.
+     * @return the size of brokerset.
+     */
     public int getSize() {
         return brokerIds.size();
     }
-
+    /**
+     * The method is used to get the alias of brokerset.
+     * @return the alias of brokerset.
+     */
     public String getBrokersetAlias() {
         return brokersetAlias;
     }
-
+    /**
+     * The method is used to set the alias of brokerset.
+     * @param brokersetAlias
+     */
     public void setBrokersetAlias(String brokersetAlias) {
         this.brokersetAlias = brokersetAlias;
     }
-
+    /**
+     * The method is used to get the ranges of brokerset.
+     * @return the ranges of brokerset.
+     */
     public List<List<Integer>> getBrokersetRanges() {
         return brokersetRanges;
     }
-
-    public void addBrokerRange(List<Integer> brokerRange) {
+    /**
+     * The method is used to add the range of brokerset.
+     * Each range is a list of two integers.
+     * @param brokerRange
+     * @throws IllegalArgumentException
+     */
+    public void addBrokerRange(List<Integer> brokerRange) throws IllegalArgumentException {
+        if (brokerRange.size() != 2) {
+            throw new IllegalArgumentException(
+                "The size of brokerRange should be 2 for brokerset " + brokersetAlias + ".");
+        }
         brokersetRanges.add(brokerRange);
     }
-
-    public void setBrokersetRanges(List<List<Integer>> brokersetRanges) {
+    /**
+     * The method is used to set the ranges of brokerset.
+     * @param brokersetRanges
+     * @throws IllegalArgumentException
+     */
+    public void setBrokersetRanges(List<List<Integer>> brokersetRanges) throws IllegalArgumentException {
+        for (List<Integer> brokerRange : brokersetRanges) {
+            if (brokerRange.size() != 2) {
+                throw new IllegalArgumentException(
+                    "The size of brokerRange should be 2 for brokerset " + brokersetAlias + ".");
+            }
+        }
         this.brokersetRanges = brokersetRanges;
     }
-
+    /**
+     * The method is used to get the ids of brokers in the brokerset.
+     * @return brokerIds
+     */
     public List<String> getBrokerIds() {
         return brokerIds;
     }
-
+    /**
+     * The method is used to set the ids of brokers in the brokerset.
+     * @param brokerIds
+     */
     public void setBrokerIds(List<String> brokerIds) {
         this.brokerIds = brokerIds;
     }

--- a/orion-server/src/main/resources/webapp/src/basic-components/Kafka/BrokersetEntry.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/Kafka/BrokersetEntry.js
@@ -1,0 +1,179 @@
+import React from "react";
+import {Tab, Tabs, Grid, Box, Link, Typography, Chip} from "@material-ui/core";
+import { Link as RouterLink, Redirect, Route, Switch } from "react-router-dom";
+import PropsTable from "../Commons/PropsTable";
+
+const routes = [
+    {
+        subpath: "assignments",
+        component: PropsTable,
+        label: "Assignments",
+        getData: getAssignmentData,
+        getColumns: getAssignmentColumns,
+    },
+    {
+        subpath: "brokers",
+        component: PropsTable,
+        label: "Brokers",
+        getData: getBrokerData,
+        getColumns: getBrokerColumns,
+    },
+    {
+        subpath: "status",
+        component: PropsTable,
+        label: "Status",
+        getData: getStatusData,
+        getColumns: getStatusColumns,
+    }
+];
+
+function getStatusData(clusterId, rawData) {
+    let brokersetStatus = [];
+    let brokersetData = rawData.brokersetData;
+    brokersetStatus.push({ key: "Broker Count", value: brokersetData.size});
+    return brokersetStatus;
+}
+
+function getStatusColumns() {
+    return [
+        { title: "Key", field: "key" },
+        { title: "Value", field: "value" },
+    ];
+}
+
+function brokerToLink(broker, clusterId) {
+    return (
+        <Link
+            component={RouterLink}
+            to={"/clusters/" + clusterId + "/nodes/" + broker}
+        >
+            {broker}
+        </Link>
+    );
+}
+
+function getBrokerData(clusterId, rawData) {
+    let brokersetData = rawData.brokersetData;
+    let brokers = [];
+    for (let brokerId of brokersetData.brokerIds) {
+        brokers.push({ broker: brokerToLink(brokerId, clusterId) });
+    }
+    return brokers;
+}
+
+function getBrokerColumns() {
+    return [
+        { title: "Broker", field: "broker" },
+    ];
+}
+
+function getAssignmentData(clusterId, rawData) {
+    let brokersetData = rawData.brokersetData;
+    let assignments = [];
+    for (let range of brokersetData.brokersetRanges) {
+        assignments.push({
+            startBrokerIdx: range[0],
+            endBrokerIdx: range[1],
+            size: range[1] - range[0] + 1
+        });
+    }
+    return assignments;
+}
+
+function getAssignmentColumns() {
+    return [
+        { title: "Start Broker Id", field: "startBrokerIdx" },
+        { title: "End Broker Id", field: "endBrokerIdx" },
+        { title: "Size", field: "size" }
+    ];
+}
+
+function BrokersetNavTabs(props) {
+    return (
+        <Tabs
+            value={props.match.params.tab}
+            style={{ backgroundColor: "white", width: "100%", maxWidth: "100%" }}
+        >
+            {routes.map((route, idx) => (
+                <Tab
+                    key={idx}
+                    value={route.subpath}
+                    label={route.label}
+                    to={route.subpath}
+                    component={RouterLink}
+                />
+            ))}
+        </Tabs>
+    );
+}
+
+function getBrokersetInfoHeader(rawData, clusterId) {
+    let brokersetData = rawData.brokersetData;
+    let brokersetAlias = brokersetData.brokersetAlias;
+    let brokerCount = brokersetData.size;
+    return (
+        <Box my={2}>
+            <Grid container display="flex" alignItems="center" spacing={2}>
+                <Grid item>
+                    <Typography variant="h6">
+                        {brokersetAlias}
+                    </Typography>
+                </Grid>
+                <Grid item>
+                    <Chip variant="outlined" label="Kafka Brokerset" size="small" />
+                </Grid>
+                <Grid item>
+                    <Chip
+                        variant="outlined"
+                        color="primary"
+                        size="small"
+                        label={brokerCount + " brokers"}
+                    />
+                </Grid>
+            </Grid>
+        </Box>
+    );
+}
+
+export default function BrokersetEntry(props) {
+    let rowData = props.rowData;
+    let clusterId = props.clusterId;
+    return (
+        <div>
+            {getBrokersetInfoHeader(rowData, clusterId)}
+            <Grid>
+                <Grid item xs={10}>
+                    <Switch>
+                        <Redirect
+                            exact
+                            from="/clusters/:clusterId/service/brokersets/:brokersetAlias"
+                            to="/clusters/:clusterId/service/brokersets/:brokersetAlias/assignments"
+                        ></Redirect>
+                        <Route
+                            path="/clusters/:clusterId/service/brokersets/:brokersetAlias/:tab"
+                            children={BrokersetNavTabs}
+                        />
+                    </Switch>
+                </Grid>
+                <Grid item xs={12}>
+                    <Switch>
+                        {routes.map((route, idx) => {
+                            return (
+                                <Route
+                                    key={idx}
+                                    exact
+                                    path={"/clusters/:clusterId/service/brokersets/:brokersetAlias/" + route.subpath}
+                                >
+                                {<route.component
+                                    data={route.getData(clusterId, rowData)}
+                                    columns={route.getColumns()}
+                                />}
+                                </Route>
+                            );
+                        })}
+                    </Switch>
+                </Grid>
+            </Grid>
+        </div>
+    )
+}

--- a/orion-server/src/main/resources/webapp/src/basic-components/Kafka/BrokersetEntry.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/Kafka/BrokersetEntry.js
@@ -19,22 +19,22 @@ const routes = [
         getColumns: getBrokerColumns,
     },
     {
-        subpath: "status",
+        subpath: "stats",
         component: PropsTable,
-        label: "Status",
-        getData: getStatusData,
-        getColumns: getStatusColumns,
+        label: "Stats",
+        getData: getStatsData,
+        getColumns: getStatsColumns,
     }
 ];
 
-function getStatusData(clusterId, rawData) {
-    let brokersetStatus = [];
+function getStatsData(clusterId, rawData) {
+    let brokersetStats = [];
     let brokersetData = rawData.brokersetData;
-    brokersetStatus.push({ key: "Broker Count", value: brokersetData.size});
-    return brokersetStatus;
+    brokersetStats.push({ key: "Broker Count", value: brokersetData.size});
+    return brokersetStats;
 }
 
-function getStatusColumns() {
+function getStatsColumns() {
     return [
         { title: "Key", field: "key" },
         { title: "Value", field: "value" },

--- a/orion-server/src/main/resources/webapp/src/basic-components/Kafka/KafkaNode.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/Kafka/KafkaNode.js
@@ -48,11 +48,11 @@ const routes = [
     getColumns: getBrokersetColumns,
   },
   {
-    subpath: "brokerstatus",
+    subpath: "brokerstats",
     component: PropsTable,
-    label: "Broker Status",
-    getData: getBrokerStatusData,
-    getColumns: getBrokerStatusColumns,
+    label: "Broker Stats",
+    getData: getBrokerStatsData,
+    getColumns: getBrokerStatsColumns,
   }
 ];
 
@@ -241,11 +241,11 @@ function getBrokersetData(cluster, node) {
   for (let brokersetAlias of brokersets) {
     const brokersetAliasSplit = brokersetAlias.split("_");
     let brokersetType = brokersetAliasSplit[0];
-    let brokerCount = "N/A";
-    let partitionCount = "N/A";
+    let brokerCount = -1;
+    let partitionCount = -1;
     if (brokersetType === "Capacity" || brokersetType === "Static") {
-      brokerCount = brokersetAliasSplit[1].replace("B", "");
-      partitionCount = brokersetAliasSplit[2].replace("P", "");
+      brokerCount = parseInt(brokersetAliasSplit[1].replace("B", ""));
+      partitionCount = parseInt(brokersetAliasSplit[2].replace("P", ""));
     }
     brokersetRows.push({
       brokersetAlias: <Box>{brokersetToLink(brokersetAlias, clusterId)}</Box>,
@@ -266,12 +266,12 @@ function getBrokersetColumns() {
     ]);
 }
 
-function getBrokerStatusData(cluster, node) {
-  let brokerStatusData = [];
-  return brokerStatusData;
+function getBrokerStatsData(cluster, node) {
+  let brokerStatsData = [];
+  return brokerStatsData;
 }
 
-function getBrokerStatusColumns() {
+function getBrokerStatsColumns() {
   return ([
       { title: "Key", field: "key" },
       { title: "Value", field: "value" }

--- a/orion-server/src/main/resources/webapp/src/basic-components/Kafka/KafkaNode.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/Kafka/KafkaNode.js
@@ -16,7 +16,6 @@
 import React from "react";
 import { Tab, Tabs, Grid, Typography, Box, Chip, Link } from "@material-ui/core";
 import { Link as RouterLink, Redirect, Route, Switch } from "react-router-dom";
-import { makeStyles } from "@material-ui/core/styles";
 import PropsTable from "../Commons/PropsTable";
 
 const routes = [
@@ -40,6 +39,20 @@ const routes = [
     label: "Broker Environment",
     getData: getBrokerEnvironmentData,
     getColumns: getBrokerEnvironmentColumns,
+  },
+  {
+    subpath: "brokersets",
+    component: PropsTable,
+    label: "Brokersets",
+    getData: getBrokersetData,
+    getColumns: getBrokersetColumns,
+  },
+  {
+    subpath: "brokerstatus",
+    component: PropsTable,
+    label: "Broker Status",
+    getData: getBrokerStatusData,
+    getColumns: getBrokerStatusColumns,
   }
 ];
 
@@ -133,6 +146,14 @@ function getNodeInfoHeader(node, nodeId, brokerId, hostname) {
               label={node.currentNodeInfo.rack}
             />
           </Grid>
+          <Grid item>
+            <Chip
+                variant="outlined"
+                color="primary"
+                size="small"
+                label={node.currentNodeInfo.brokersets.length + " brokersets"}
+            />
+          </Grid>
         </Grid>
       </Box>
     </div>
@@ -199,6 +220,61 @@ function getTopicPartitionsColumns() {
     { title: "Is Leader?", field: "isLeader" },
     { title: "Preferred Leader?", field: "isPreferredLeader" },
     { title: "Size (GB)", field: "size", type: "numeric" }
+  ]);
+}
+
+function brokersetToLink(brokerset, clusterId) {
+  return (
+      <Link
+          component={RouterLink}
+          to={"/clusters/" + clusterId + "/service/brokersets/" + brokerset + "/status"}
+      >
+        {brokerset}
+      </Link>
+  );
+}
+
+function getBrokersetData(cluster, node) {
+  let clusterId = node.currentNodeInfo.clusterId;
+  let brokersets = node.currentNodeInfo.brokersets;
+  let brokersetRows = [];
+  for (let brokersetAlias of brokersets) {
+    const brokersetAliasSplit = brokersetAlias.split("_");
+    let brokersetType = brokersetAliasSplit[0];
+    let brokerCount = "N/A";
+    let partitionCount = "N/A";
+    if (brokersetType === "Capacity" || brokersetType === "Static") {
+      brokerCount = brokersetAliasSplit[1].replace("B", "");
+      partitionCount = brokersetAliasSplit[2].replace("P", "");
+    }
+    brokersetRows.push({
+      brokersetAlias: <Box>{brokersetToLink(brokersetAlias, clusterId)}</Box>,
+      type: brokersetType,
+      brokerCount: brokerCount,
+      partitionCount: partitionCount
+    });
+  }
+  return brokersetRows;
+}
+
+function getBrokersetColumns() {
+    return ([
+      { title: "Brokerset Name", field: "brokersetAlias" },
+      { title: "Type", field: "type" },
+      { title: "Broker Count", field: "brokerCount" },
+      { title: "Partition Count", field: "partitionCount" }
+    ]);
+}
+
+function getBrokerStatusData(cluster, node) {
+  let brokerStatusData = [];
+  return brokerStatusData;
+}
+
+function getBrokerStatusColumns() {
+  return ([
+      { title: "Key", field: "key" },
+      { title: "Value", field: "value" }
   ]);
 }
 

--- a/orion-server/src/main/resources/webapp/src/basic-components/Kafka/KafkaNode.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/Kafka/KafkaNode.js
@@ -227,7 +227,7 @@ function brokersetToLink(brokerset, clusterId) {
   return (
       <Link
           component={RouterLink}
-          to={"/clusters/" + clusterId + "/service/brokersets/" + brokerset + "/status"}
+          to={"/clusters/" + clusterId + "/service/brokersets/" + brokerset + "/stats"}
       >
         {brokerset}
       </Link>


### PR DESCRIPTION
### Code Review Summary: Orion Broker Set UI Implementation  
  
#### Enhancements to Broker Set Section on Service Page  
- Introduced a new header.  
- Added three sub-sections:  
  1. **Assignments:** Displays start broker ID to end broker ID.  
  2. **Broker Links**  
  3. **Status:** Reserved for future use.  
  
#### Improvements to Node Page  
- Added a new label in the header to show the broker set count.  
- Introduced a broker set section that records all broker sets.  
- Added a broker status section, which is reserved for future use.  
  
#### Class Updates  
The existing `BrokerSet` class is generated from a configuration file every 2 minutes, which means it cannot currently save state information. Additionally, it plays a critical role in the existing topic assignment logic. To avoid disrupting any existing logic during refactoring, a new `BrokerSetState` class has been added.  
  
#### Testing  
This change has been tested via branch deployment.  