### PR TITLE
Add tag:environment to AMI filter criteria

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/AmiTagManager.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/aws/AmiTagManager.java
@@ -50,6 +50,7 @@ public class AmiTagManager {
   public static final String KEY_APPLICATION = "application";
   public static final String KEY_RELEASE = "release";
   public static final String KEY_ARCHITECTURE = "architecture";
+  public static final String KEY_ENVIRONMENT = "environment";
   public static final String KEY_APPLICATION_ENVIRONMENT = "application_environment";
   public static final String VALUE_KAFKA = "kafka";
   public static UnaryOperator<String> tag = key -> "tag:" + key;
@@ -85,6 +86,12 @@ public class AmiTagManager {
       filterList.add(
         filterBuilder.name(KEY_ARCHITECTURE)
           .values(filter.get(KEY_ARCHITECTURE))
+          .build()
+      );
+    if (filter.containsKey(KEY_ENVIRONMENT))
+      filterList.add(
+        filterBuilder.name(tag.apply(KEY_ENVIRONMENT))
+          .values(filter.get(KEY_ENVIRONMENT))
           .build()
       );
     filterList.add(

--- a/orion-server/src/main/java/com/pinterest/orion/server/api/ClusterManagerApi.java
+++ b/orion-server/src/main/java/com/pinterest/orion/server/api/ClusterManagerApi.java
@@ -119,13 +119,16 @@ public class ClusterManagerApi extends BaseClustersApi {
   @GET
   public List<Ami> describeImages(
       @QueryParam(AmiTagManager.KEY_RELEASE) String os,
-      @QueryParam(AmiTagManager.KEY_ARCHITECTURE) String arch
+      @QueryParam(AmiTagManager.KEY_ARCHITECTURE) String arch,
+      @QueryParam(AmiTagManager.KEY_ENVIRONMENT) String environment
   ) {
     Map<String, String> filter = new HashMap<>();
     if (os != null)
       filter.put(AmiTagManager.KEY_RELEASE, os);
     if (arch != null)
       filter.put(AmiTagManager.KEY_ARCHITECTURE, arch);
+    if (environment != null)
+      filter.put(AmiTagManager.KEY_ENVIRONMENT, environment);
     if (amiTagManager == null)
       amiTagManager = new AmiTagManager();
     return amiTagManager.getAmiList(filter);

--- a/orion-server/src/main/resources/webapp/src/basic-components/Ami.js
+++ b/orion-server/src/main/resources/webapp/src/basic-components/Ami.js
@@ -53,6 +53,12 @@ function Ami({ amiList, requestAmiList, envTypes, requestEnvTypes, updateAmiTag 
   const handleArchChange = event => {
     setArch(event.target.value);
   };
+  const [environment, setEnvironment] = React.useState();
+  if (environment == undefined)
+    setEnvironment("prod")
+  const handleEnvironmentChange = event => {
+    setEnvironment(event.target.value);
+  };
   const [selected, setSelected] = React.useState([]);
   const [env, setEnv] = React.useState({});
   if (envTypes !== undefined && Object.keys(env).length == 0) {
@@ -85,6 +91,8 @@ function Ami({ amiList, requestAmiList, envTypes, requestEnvTypes, updateAmiTag 
       parms.push("release=" + os);
     if (arch)
       parms.push("architecture=" + arch);
+    if (environment)
+      parms.push("environment=" + environment);
     requestAmiList(parms.join('&'));
     requestEnvTypes();
   }
@@ -139,6 +147,21 @@ function Ami({ amiList, requestAmiList, envTypes, requestEnvTypes, updateAmiTag 
               >
                 <MenuItem value={"x86_64"}>x86_64</MenuItem>
                 <MenuItem value={"arm64"}>arm64</MenuItem>
+              </Select>
+            </FormControl>
+          </div>
+          <div>
+            <FormControl className={classes.formControl}>
+              <InputLabel id="lblEnvironment">OS</InputLabel>
+              <Select
+                labelId="lblSelectEnvironment"
+                id="selectEnvironment"
+                value={environment}
+                onChange={handleEnvironmentChange}
+                style={{ width: "200px", textAlign: "left" }}
+              >
+                <MenuItem value={"prod"}>prod</MenuItem>
+                <MenuItem value={"test"}>test</MenuItem>
               </Select>
             </FormControl>
           </div>


### PR DESCRIPTION
## Summary:

AMI tag 'environment' allow values prod and test. When replacing nodes in Kafka clusters it's important to be able to select AMIs based on their tag 'environment', along with other criteria.

## Test Plan:

- [X] Node successfully replaced in dev Orion, using environment=test.

Cluster configuration:

```
  - clusterId: upgradekafka01
    type: kafka
    configuration:
      image:
        application: kafka
        release: bionic
        architecture: x86_64
        environment: test
        application_environment: dev
```

Target AMI correctly tagged:
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/1a17c03f-833e-464f-a70c-111b027a3e9c">

Node replacement successful with correct AMI:
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/bfceed6b-3b27-43b4-9137-28773c8f4920">



- [X] Node successfully replaced in dev Orion, using environment=prod.

Cluster configuration (no environment, defaults to prod):

```
  - clusterId: upgradekafka01
    type: kafka
    configuration:
      image:
        application: kafka
        release: bionic
        architecture: x86_64
        application_environment: dev
```

Target AMI correctly tagged:
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/50b070c3-73e1-40b0-85bf-b1608567ad16">

Node replacement successful:
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/3dbb507e-a02c-4ed1-b416-46430a382f1d">

```
brunorodrigues@lancerkafka-canary-0a033c99:~$ tail -f /var/log/orion/orion.log | grep CMDBFallbackReplaceBroker
INFO  [2024-10-02 19:53:49,029] com.pinterest.orion.internal.core.actions.kafka.CMDBFallbackReplaceBrokerAction: Spiffe id exists. Skip userdata update. Existing userdata: #cloud-config
INFO  [2024-10-02 19:53:49,263] com.pinterest.orion.internal.core.actions.kafka.CMDBFallbackReplaceBrokerAction: Current AMI is ami-072a9b7aea157c353
INFO  [2024-10-02 19:53:49,263] com.pinterest.orion.internal.core.actions.kafka.CMDBFallbackReplaceBrokerAction: Image selection config: {application=kafka, release=bionic, architecture=x86_64, application_environment=dev}
INFO  [2024-10-02 19:53:55,845] com.pinterest.orion.internal.core.actions.kafka.CMDBFallbackReplaceBrokerAction: Selected AMI ami-00d45b753bc938156
INFO  [2024-10-02 19:53:55,895] com.pinterest.orion.internal.core.actions.kafka.CMDBFallbackReplaceBrokerAction: EBS volume size override of 25GB requested for:kafka-upgrade01-dev-001
```