### PR TITLE
Fix orion error caused by brokers removed outside orion

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqClusterSensor.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/sensor/memq/MemqClusterSensor.java
@@ -83,11 +83,11 @@ public class MemqClusterSensor extends MemqSensor {
         } catch (KeeperException.NoNodeException e) {
           cluster.getNodeMap().remove(brokerName);
           logger.info(
-              "Broker data of " + brokerName + " is not available in zookeeper. It may have been removed.");
+              "Broker data of " + brokerName + " is not available in zookeeper. The broker might be removed.");
           continue;
         } catch (Exception e) {
           logger.severe(
-              "Face unknown exception when getting broker data for " + brokerName +" from zookeeper:" + e);
+              "Faced an unknown exception when getting broker data for " + brokerName +" from zookeeper:" + e);
           continue;
         }
         Broker broker = gson.fromJson(new String(brokerData), Broker.class);


### PR DESCRIPTION
If brokers are removed outside orion, the zk call getting broker data can fail. Add logic to handle this exception. 
After the loop, the sensor also updates the cluster broker map to make sure all nodes are still in ZK. 