### PR TITLE
Enhancements to Broker Recovery Process  

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/BrokerRecoveryAction.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/actions/kafka/BrokerRecoveryAction.java
@@ -97,7 +97,7 @@ public class BrokerRecoveryAction extends NodeAction {
         stopServiceBeforeAction = getAttribute(ATTR_STOP_SERVICE_BEFORE_ACTION).getValue();
       }
       if (stopServiceBeforeAction) {
-        // Metrics
+        OrionServer.METRICS.counter(metricPrefix.resolve("stop_service_before_action")).inc();
         try {
           ServiceStopAction stopServiceAction = new ServiceStopAction();
           stopServiceAction.copyAttributeFrom(this, OrionConstants.NODE_ID);


### PR DESCRIPTION
This PR introduces logic to attempt stopping the Kafka service on a broker before executing other broker recovery actions. This action triggers leadership failover, allowing other brokers to become leaders of Kafka topic partitions.  