### PR TITLE
Move brokerset check block

### DIFF
--- a/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
+++ b/orion-server/src/main/java/com/pinterest/orion/core/automation/operator/kafka/BrokersetTopicOperator.java
@@ -143,12 +143,6 @@ public class BrokersetTopicOperator extends KafkaOperator {
       KafkaTopicDescription actualTopicDescription = topicDescriptionMap.get(topicName);
       Brokerset brokerset = brokersetMap.get(brokersetAlias);
 
-      if (brokerset == null) {
-        logger.warning("Topic(" + topicName + ") Attempted to use Brokerset(" + brokersetAlias + ") which doesn't exist.");
-        OrionServer.METRICS.counter(metric.resolve("non_existent_brokerset")).inc();
-        continue;
-      }
-
       if (topicAssignment.isDelete()) {
         if (enableTopicDeletion) {
           if (actualTopicDescription == null) {
@@ -159,6 +153,12 @@ public class BrokersetTopicOperator extends KafkaOperator {
             dispatch(action);
           }
         }
+        continue;
+      }
+
+      if (brokerset == null) {
+        logger.warning("Topic(" + topicName + ") Attempted to use Brokerset(" + brokersetAlias + ") which doesn't exist.");
+        OrionServer.METRICS.counter(metric.resolve("non_existent_brokerset")).inc();
         continue;
       }
 


### PR DESCRIPTION
To avoid validating brokerset of deleted topics, move the check block to after where deleted topics are processed.

This change should avoid warning messages like this in the log for deleted topics:
```
com.pinterest.orion.core.automation.operator.kafka.BrokersetTopicOperator: Topic(...) Attempted to use Brokerset(...) which doesn't exist.
```