### PR TITLE
Pin react-draggable to 4.2.0

### DIFF
--- a/orion-server/src/main/resources/webapp/package.json
+++ b/orion-server/src/main/resources/webapp/package.json
@@ -18,7 +18,7 @@
     "react": "^16.9.0",
     "react-apexcharts": "~1.5.0",
     "react-dom": "^16.9.0",
-    "react-draggable": "^4.2.0",
+    "react-draggable": "4.2.0",
     "react-final-form": "^6.5.0",
     "react-json-view": "^1.19.1",
     "react-redux": "^7.1.3",


### PR DESCRIPTION
Try to fix `react-scripts build` compile issue:

```
> react-scripts build
Creating an optimized production build...
Failed to compile.
./node_modules/react-draggable/build/cjs/Draggable.js 260:22
Module parse failed: Unexpected token (260:22)
File was processed with these loaders:
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
|   // the underlying DOM node ourselves. See the README for more information.
|   findDOMNode() /*: ?HTMLElement*/{
>     return this.props?.nodeRef?.current ?? _reactDom.default.findDOMNode(this);
|   }
|   render() /*: ReactElement<any>*/{
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! orion-ui@0.1.0 build: `react-scripts build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the orion-ui@0.1.0 build script.
```